### PR TITLE
[#85] 합성된 Dropdown.Default 컴포넌트 작업

### DIFF
--- a/src/components/shared/dropdown/DefaultDropdown.tsx
+++ b/src/components/shared/dropdown/DefaultDropdown.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+import CompositeDropdown from './compositeDropdown';
+import { DefaultDropdownProps, SelectedOption } from './types';
+import { handlePanelKey } from '@/utils/dropdown/handlePanelKey';
+import { useDropdownOptionsKey } from '@/hooks/dropdown/useDropdownOptionsKey';
+import { renderDropdownOptions } from './renderDropdownDoptions';
+import { useSelectedOption } from '@/hooks/dropdown/useSelectedOption';
+
+/**
+ * 기본으로 사용될 Dropdown 컴포넌트
+ *
+ * @example
+      export default function CSH() {
+        function selectOption(selected: SelectedOption) {
+          console.log(selected);
+        }
+
+        return (
+          <>
+            <Dropdown.Default
+              label="테스트"
+              initialOptions={[
+                { value: 'test 1', text: 'text 1' },
+                { value: 'test 2', text: 'text 2', selected: true },
+              ]}
+              selectOption={selectOption}
+            />
+          </>
+        );
+      }
+ */
+export default function DefaultDropdown({
+  label,
+  initialOptions = [],
+  selectOption,
+}: DefaultDropdownProps) {
+  const { selectedDataset, selectedOption, handleSelected } =
+    useSelectedOption(initialOptions);
+  const [isOpen, setIsOpen] = useState(false);
+  const [options] = useState<Array<SelectedOption>>(initialOptions);
+  const { focusedIndex, handleOptionsKey } = useDropdownOptionsKey({
+    options,
+    handleSelected,
+    setIsOpen,
+  });
+
+  useEffect(() => {
+    selectOption(selectedOption);
+  }, [selectedOption]);
+
+  return (
+    <>
+      <CompositeDropdown
+        onClick={() => setIsOpen((prev) => !prev)}
+        handlePanelKey={handlePanelKey}
+        isOpen={isOpen}
+      >
+        <CompositeDropdown.Label>{label}</CompositeDropdown.Label>
+        <CompositeDropdown.Select>
+          {selectedOption?.text === undefined
+            ? ''
+            : selectedOption.text}
+        </CompositeDropdown.Select>
+        {isOpen && (
+          <CompositeDropdown.Panel
+            onClick={handleSelected}
+            handleOptionsKey={handleOptionsKey}
+          >
+            {() =>
+              renderDropdownOptions(
+                options,
+                selectedDataset,
+                focusedIndex,
+              )
+            }
+          </CompositeDropdown.Panel>
+        )}
+      </CompositeDropdown>
+    </>
+  );
+}

--- a/src/components/shared/dropdown/DefaultDropdown.tsx
+++ b/src/components/shared/dropdown/DefaultDropdown.tsx
@@ -8,7 +8,12 @@ import { useSelectedOption } from '@/hooks/dropdown/useSelectedOption';
 
 /**
  * 기본으로 사용될 Dropdown 컴포넌트
- *
+ * @description
+ * initialOptions 
+ *   - 배열의 0번 인덱스에 들어갈 Option 객체의 value가 빈 문자열 ("")이라면
+ *     - 해당 객체의 text 값은 기본 안내 메시지가 되며
+ *     - Panel에서 해당 Option 객체 선택 불가  
+ * 
  * @example
       export default function CSH() {
         function selectOption(selected: SelectedOption) {
@@ -20,8 +25,9 @@ import { useSelectedOption } from '@/hooks/dropdown/useSelectedOption';
             <Dropdown.Default
               label="테스트"
               initialOptions={[
+                { value: '', text: '탈퇴사유를 선택해주세요.' },
                 { value: 'test 1', text: 'text 1' },
-                { value: 'test 2', text: 'text 2', selected: true },
+                { value: 'test 2', text: 'text 2' },
               ]}
               selectOption={selectOption}
             />
@@ -45,24 +51,44 @@ export default function DefaultDropdown({
   });
 
   useEffect(() => {
-    selectOption(selectedOption);
+    if (selectedOption.value !== '') {
+      selectOption(selectedOption);
+    }
   }, [selectedOption]);
 
+  const selectedValue = selectedOption?.value !== '';
   return (
     <>
       <CompositeDropdown
+        className="w-[386px] cursor-pointer"
         onClick={() => setIsOpen((prev) => !prev)}
         handlePanelKey={handlePanelKey}
         isOpen={isOpen}
       >
-        <CompositeDropdown.Label>{label}</CompositeDropdown.Label>
-        <CompositeDropdown.Select>
+        <CompositeDropdown.Label className="b4 font-medium text-primary-900">
+          {label}
+        </CompositeDropdown.Label>
+        <CompositeDropdown.Select
+          // className={selectedOption?.value === '' ? '' : ''}
+          classNameWrapper={
+            'flex border border-grayscale-300 rounded-lg w-full p-4 gap-4 my-1 hover:bg-grayscale-100'
+          }
+          classNameSelected={`b4 font-normal text-grayscale-${
+            selectedValue ? '900' : '400'
+          } flex-grow-[929] flex-shrink flex-basis-0`}
+          classNameSVG={`transform transition-transform duration-300 ${
+            isOpen ? 'rotate-180' : ''
+          } text-grayscale-${
+            selectedValue ? '900' : '400'
+          } w-6 h-6 flex-grow-[71] flex-shrink flex-basis-0`}
+        >
           {selectedOption?.text === undefined
             ? ''
             : selectedOption.text}
         </CompositeDropdown.Select>
         {isOpen && (
           <CompositeDropdown.Panel
+            className={`border border-grayscale-300 rounded-lg`}
             onClick={handleSelected}
             handleOptionsKey={handleOptionsKey}
           >

--- a/src/components/shared/dropdown/DropdownLabel.tsx
+++ b/src/components/shared/dropdown/DropdownLabel.tsx
@@ -1,7 +1,0 @@
-export default function DropdownLabel({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <>{children}</>;
-}

--- a/src/components/shared/dropdown/DropdownMain.tsx
+++ b/src/components/shared/dropdown/DropdownMain.tsx
@@ -1,0 +1,7 @@
+export default function DropdownMain({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/components/shared/dropdown/DropdownOption.tsx
+++ b/src/components/shared/dropdown/DropdownOption.tsx
@@ -1,7 +1,0 @@
-export default function DropDownOption({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <>{children}</>;
-}

--- a/src/components/shared/dropdown/DropdownPanel.tsx
+++ b/src/components/shared/dropdown/DropdownPanel.tsx
@@ -1,7 +1,0 @@
-export default function DropDownPanel({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <>{children}</>;
-}

--- a/src/components/shared/dropdown/DropdownSelect.tsx
+++ b/src/components/shared/dropdown/DropdownSelect.tsx
@@ -1,7 +1,0 @@
-export default function DropdownSelect({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <>{children}</>;
-}

--- a/src/components/shared/dropdown/DropdownWrapper.tsx
+++ b/src/components/shared/dropdown/DropdownWrapper.tsx
@@ -1,7 +1,0 @@
-export default function DropdownWrapper({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <>{children}</>;
-}

--- a/src/components/shared/dropdown/compositeDropdown/CompDropdownLabel.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/CompDropdownLabel.tsx
@@ -1,0 +1,9 @@
+export default function CompDropdownLabel({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <div className={className}>{children}</div>;
+}

--- a/src/components/shared/dropdown/compositeDropdown/CompDropdownOption.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/CompDropdownOption.tsx
@@ -1,0 +1,25 @@
+import { CompDropdownOptionProps } from './types';
+import { useFocusOption } from '@/hooks/dropdown/useFocusOption';
+
+export default function CompDropDownOption({
+  children,
+  className,
+  value,
+  selected = false,
+  index,
+  focusedIndex,
+}: CompDropdownOptionProps) {
+  const { focusedRef } = useFocusOption(focusedIndex, index);
+
+  return (
+    <li
+      ref={focusedRef}
+      className={`${className} ${selected ? 'bg-primary-50' : ''}`}
+      value={value}
+      data-value={value}
+      tabIndex={0}
+    >
+      {children}
+    </li>
+  );
+}

--- a/src/components/shared/dropdown/compositeDropdown/CompDropdownOption.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/CompDropdownOption.tsx
@@ -14,7 +14,7 @@ export default function CompDropDownOption({
   return (
     <li
       ref={focusedRef}
-      className={`${className} ${selected ? 'bg-primary-50' : ''}`}
+      className={`${className} ${selected ? 'font-semibold' : ''}`}
       value={value}
       data-value={value}
       tabIndex={0}

--- a/src/components/shared/dropdown/compositeDropdown/CompDropdownPanel.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/CompDropdownPanel.tsx
@@ -5,9 +5,11 @@ export default function CompDropDownPanel({
   children,
   handleOptionsKey,
   onClick,
+  className,
 }: CompDropdownPanelProps) {
   return (
     <ul
+      className={className}
       onClick={(e) =>
         handleDropdownStatus(e, onClick, handleOptionsKey)
       }

--- a/src/components/shared/dropdown/compositeDropdown/CompDropdownPanel.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/CompDropdownPanel.tsx
@@ -1,0 +1,21 @@
+import { handleDropdownStatus } from '@/utils/dropdown/handleDropdownStatus';
+import { CompDropdownPanelProps } from './types';
+
+export default function CompDropDownPanel({
+  children,
+  handleOptionsKey,
+  onClick,
+}: CompDropdownPanelProps) {
+  return (
+    <ul
+      onClick={(e) =>
+        handleDropdownStatus(e, onClick, handleOptionsKey)
+      }
+      onKeyDown={(e) =>
+        handleDropdownStatus(e, onClick, handleOptionsKey)
+      }
+    >
+      {children()}
+    </ul>
+  );
+}

--- a/src/components/shared/dropdown/compositeDropdown/CompDropdownSelect.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/CompDropdownSelect.tsx
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+export default function CompDropdownSelect({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div tabIndex={0} className={`${className} `}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/shared/dropdown/compositeDropdown/CompDropdownSelect.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/CompDropdownSelect.tsx
@@ -1,15 +1,27 @@
-import { useState } from 'react';
+import Down from '@/assets/icons/down.svg';
 
 export default function CompDropdownSelect({
   children,
-  className,
+  classNameWrapper,
+  classNameSelected,
+  classNameSVG,
 }: {
   children: React.ReactNode;
   className?: string;
+  classNameWrapper?: string;
+  classNameSelected?: string;
+  classNameSVG?: string;
 }) {
+  /**
+   * span: 314 / (314 + 24) = 0.929
+     Down: 24 / (314 + 24) = 0.071
+   */
   return (
-    <div tabIndex={0} className={`${className} `}>
-      {children}
+    <div tabIndex={0} className={classNameWrapper}>
+      {/* <span className={`b4 font-medium text-grayscale-900`}> */}
+      <span className={classNameSelected}>{children}</span>
+      <Down className={classNameSVG} />
+      {/* <Down className={`text-grayscale-900 w-6 h-6`} /> */}
     </div>
   );
 }

--- a/src/components/shared/dropdown/compositeDropdown/CompDropdownWrapper.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/CompDropdownWrapper.tsx
@@ -1,0 +1,31 @@
+import { SetIsOpenType } from '../types';
+
+export default function CompDropdownWrapper({
+  children,
+  onClick,
+  handlePanelKey,
+  isOpen,
+}: {
+  children: React.ReactNode;
+  onClick: (isEnter: boolean) => void;
+  handlePanelKey: (
+    e: React.KeyboardEvent<HTMLUListElement>,
+    onClick: (isEnter: boolean) => void,
+  ) => void;
+  isOpen: boolean;
+}) {
+  function handleKeyDown(e: React.KeyboardEvent<HTMLUListElement>) {
+    if (!isOpen) {
+      handlePanelKey(e, onClick);
+    }
+  }
+
+  return (
+    <section
+      onClick={() => onClick(!isOpen)}
+      onKeyDown={handleKeyDown}
+    >
+      {children}
+    </section>
+  );
+}

--- a/src/components/shared/dropdown/compositeDropdown/CompDropdownWrapper.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/CompDropdownWrapper.tsx
@@ -5,6 +5,7 @@ export default function CompDropdownWrapper({
   onClick,
   handlePanelKey,
   isOpen,
+  className,
 }: {
   children: React.ReactNode;
   onClick: (isEnter: boolean) => void;
@@ -13,6 +14,7 @@ export default function CompDropdownWrapper({
     onClick: (isEnter: boolean) => void,
   ) => void;
   isOpen: boolean;
+  className?: string;
 }) {
   function handleKeyDown(e: React.KeyboardEvent<HTMLUListElement>) {
     if (!isOpen) {
@@ -22,6 +24,7 @@ export default function CompDropdownWrapper({
 
   return (
     <section
+      className={className}
       onClick={() => onClick(!isOpen)}
       onKeyDown={handleKeyDown}
     >

--- a/src/components/shared/dropdown/compositeDropdown/index.tsx
+++ b/src/components/shared/dropdown/compositeDropdown/index.tsx
@@ -1,0 +1,38 @@
+import DropdownLabel from './CompDropdownLabel';
+import DropDownOption from './CompDropdownOption';
+import DropDownPanel from './CompDropdownPanel';
+import DropdownSelect from './CompDropdownSelect';
+import DropdownWrapper from './CompDropdownWrapper';
+
+/**
+ * Dropdown은 분리된 컴포넌트를 사용처에서 조합해 사용합니다.
+ * 개발 진행 상황에 따라 사용 예시 및 설명이 변경도리 수 있습니다.
+ *
+ * @property {Component} Label - 무엇에 관한 Dropdwon 인지 표시
+ * @property {Component} Select - Dropdwon Panel을 여는 트리거 역할
+ * @property {Component} Panel - Option 목록을 포함한 인터페이스 요소
+ * @property {Component} Option - Dropdown 메뉴에서 사용자가 선택할 수 있는 개별 항목
+ *
+ * @example
+      <Dropdown>
+        <Dropdown.Label>회원탈퇴 사유</Dropdown.Label>
+        <Dropdown.Select onChange={handleChange}>
+          {selected}
+        </Dropdown.Select>
+        <Dropdown.Panel onChange={handleOptionChange}>
+          <Dropdown.Option value={'사유1'}>
+            첫 번째 사유
+          </Dropdown.Option>
+          <Dropdown.Option value={'사유2'}>
+            두 번째 사유
+          </Dropdown.Option>
+        </Dropdown.Panel>
+      </Dropdown>
+ */
+export const CompositeDropdown = Object.assign(DropdownWrapper, {
+  Label: DropdownLabel,
+  Select: DropdownSelect,
+  Panel: DropDownPanel,
+  Option: DropDownOption,
+});
+export default CompositeDropdown;

--- a/src/components/shared/dropdown/compositeDropdown/types.ts
+++ b/src/components/shared/dropdown/compositeDropdown/types.ts
@@ -16,4 +16,5 @@ export type CompDropdownPanelProps = {
     datasetValue: string,
   ) => void;
   onClick: (value: string) => void;
+  className?: string;
 };

--- a/src/components/shared/dropdown/compositeDropdown/types.ts
+++ b/src/components/shared/dropdown/compositeDropdown/types.ts
@@ -1,0 +1,19 @@
+import { SelectedOption } from '../types';
+
+export type CompDropdownOptionProps = {
+  children: React.ReactNode;
+  className?: string;
+  value: any;
+  selected?: boolean;
+  focusedIndex: number;
+  index: number;
+};
+
+export type CompDropdownPanelProps = {
+  children: () => Array<React.ReactElement<HTMLLIElement>>;
+  handleOptionsKey: (
+    e: React.KeyboardEvent<HTMLUListElement>,
+    datasetValue: string,
+  ) => void;
+  onClick: (value: string) => void;
+};

--- a/src/components/shared/dropdown/index.tsx
+++ b/src/components/shared/dropdown/index.tsx
@@ -1,38 +1,6 @@
-import DropdownLabel from './DropdownLabel';
-import DropDownOption from './DropdownOption';
-import DropDownPanel from './DropdownPanel';
-import DropdownSelect from './DropdownSelect';
-import DropdownWrapper from './DropdownWrapper';
+import DefaultDropdown from './DefaultDropdown';
+import DropdownMain from './DropdownMain';
 
-/**
- * Dropdown은 분리된 컴포넌트를 사용처에서 조합해 사용합니다.
- * 개발 진행 상황에 따라 사용 예시 및 설명이 변경도리 수 있습니다.
- *
- * @property {Component} Label - 무엇에 관한 Dropdwon 인지 표시
- * @property {Component} Select - Dropdwon Panel을 여는 트리거 역할
- * @property {Component} Panel - Option 목록을 포함한 인터페이스 요소
- * @property {Component} Option - Dropdown 메뉴에서 사용자가 선택할 수 있는 개별 항목
- *
- * @example
-      <Dropdown>
-        <Dropdown.Label>회원탈퇴 사유</Dropdown.Label>
-        <Dropdown.Select onChange={handleChange}>
-          {selected}
-        </Dropdown.Select>
-        <Dropdown.Panel onChange={handleOptionChange}>
-          <Dropdown.Option value={'사유1'}>
-            첫 번째 사유
-          </Dropdown.Option>
-          <Dropdown.Option value={'사유2'}>
-            두 번째 사유
-          </Dropdown.Option>
-        </Dropdown.Panel>
-      </Dropdown>
- */
-export const Dropdown = Object.assign(DropdownWrapper, {
-  Label: DropdownLabel,
-  Select: DropdownSelect,
-  Panel: DropDownPanel,
-  Option: DropDownOption,
+export const Dropdown = Object.assign(DropdownMain, {
+  Default: DefaultDropdown,
 });
-export default Dropdown;

--- a/src/components/shared/dropdown/renderDropdownDoptions.tsx
+++ b/src/components/shared/dropdown/renderDropdownDoptions.tsx
@@ -37,6 +37,7 @@ export function renderDropdownOptions(
       selectedDataset === '' && selected
         ? selected
         : selectedDataset === value;
+    const isLastOption = index !== options.length - 1;
 
     return (
       <CompositeDropdown.Option
@@ -45,6 +46,9 @@ export function renderDropdownOptions(
         selected={isSelected}
         focusedIndex={focusedIndex}
         index={index}
+        className={`hover:bg-grayscale-100 py-4 pl-4 pr-14 b4 font-normal text-grayscale-900 ${
+          isLastOption ? 'border-b border-grayscale-100' : ''
+        }`}
       >
         {text}
       </CompositeDropdown.Option>

--- a/src/components/shared/dropdown/renderDropdownDoptions.tsx
+++ b/src/components/shared/dropdown/renderDropdownDoptions.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import CompositeDropdown from './compositeDropdown';
+import { SelectedOption } from './types';
+
+/**
+ * @function renderDropdownOptions
+ * @description
+ * 드롭다운 옵션들을 렌더링하는 함수
+ *
+ * @param options - 렌더링할 드롭다운 옵션들의 배열
+ * @param selectedDataset - 현재 선택된 데이터셋 값
+ * @param focusedIndex - 포커스된 옵션의 인덱스
+ *
+ * @returns 드롭다운 옵션들을 렌더링한 React 엘리먼트 배열
+ *
+ * @example
+    <CompositeDropdown.Panel
+      onClick={handleSelected}
+      handleOptionsKey={handleOptionsKey}
+    >
+      {() =>
+        renderDropdownOptions(
+          options,
+          selectedDataset,
+          focusedIndex,
+        )
+      }
+    </CompositeDropdown.Panel>
+ */
+export function renderDropdownOptions(
+  options: SelectedOption[],
+  selectedDataset: string,
+  focusedIndex: number,
+) {
+  return options.map(({ value, text, selected = false }, index) => {
+    const isSelected =
+      selectedDataset === '' && selected
+        ? selected
+        : selectedDataset === value;
+
+    return (
+      <CompositeDropdown.Option
+        key={value}
+        value={value}
+        selected={isSelected}
+        focusedIndex={focusedIndex}
+        index={index}
+      >
+        {text}
+      </CompositeDropdown.Option>
+    );
+  });
+}

--- a/src/components/shared/dropdown/types.ts
+++ b/src/components/shared/dropdown/types.ts
@@ -1,0 +1,14 @@
+export type SelectedOption = {
+  value: string;
+  text: string;
+  selected?: boolean;
+};
+export type DefaultDropdownProps = {
+  label: string;
+  initialOptions: Array<SelectedOption>;
+  selectOption: (selected: SelectedOption) => void;
+};
+
+export type SetIsOpenType = React.Dispatch<
+  React.SetStateAction<boolean>
+>;

--- a/src/hooks/dropdown/useDropdownOptionsKey.tsx
+++ b/src/hooks/dropdown/useDropdownOptionsKey.tsx
@@ -27,11 +27,15 @@ export function useDropdownOptionsKey({
     e: React.KeyboardEvent<HTMLUListElement>,
     datasetValue: string,
   ) {
+    const isMessage = options[0]?.value === '';
+    const startIndex = isMessage ? 1 : 0;
     const len = options.length;
 
     switch (e.key) {
       case 'ArrowUp':
-        setFocusedIndex((prevIndex) => Math.max(prevIndex - 1, 0));
+        setFocusedIndex((prevIndex) =>
+          Math.max(prevIndex - 1, startIndex),
+        );
         break;
       case 'ArrowDown':
         setFocusedIndex((prevIndex) =>

--- a/src/hooks/dropdown/useDropdownOptionsKey.tsx
+++ b/src/hooks/dropdown/useDropdownOptionsKey.tsx
@@ -1,0 +1,55 @@
+import { SelectedOption } from '@/components/shared/dropdown/types';
+import { useState } from 'react';
+
+type UseDropdownOptionsKeyProps = {
+  options: Array<SelectedOption>;
+  handleSelected: (value: string) => void;
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+/**
+ * @function useDropdownOptionsKey
+ * @description
+ * 드롭다운 옵션의 키보드 이벤트를 처리
+ *
+ * @param options - 드롭다운 옵션의 배열
+ * @param handleSelected - 옵션 선택을 처리하는 함수
+ * @param setIsOpen - 드롭다운의 열림 상태를 설정하는 함수
+ */
+export function useDropdownOptionsKey({
+  options,
+  handleSelected,
+  setIsOpen,
+}: UseDropdownOptionsKeyProps) {
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
+  function handleOptionsKey(
+    e: React.KeyboardEvent<HTMLUListElement>,
+    datasetValue: string,
+  ) {
+    const len = options.length;
+
+    switch (e.key) {
+      case 'ArrowUp':
+        setFocusedIndex((prevIndex) => Math.max(prevIndex - 1, 0));
+        break;
+      case 'ArrowDown':
+        setFocusedIndex((prevIndex) =>
+          Math.min(prevIndex + 1, len - 1),
+        );
+        break;
+      case 'Enter':
+      case 'Tab':
+        handleSelected(datasetValue);
+        setIsOpen(false);
+        break;
+      case 'Escape':
+        setIsOpen(false);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return { focusedIndex, handleOptionsKey };
+}

--- a/src/hooks/dropdown/useFocusOption.tsx
+++ b/src/hooks/dropdown/useFocusOption.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * @function useFocusOption
+ * @description
+ * 드롭다운 메뉴 내에서 특정 옵션에 대한 포커싱 관리
+ *
+ * @param focusedIndex - 현재 포커스된 옵션의 인덱스
+ * @param index - 해당 훅이 관리하고 있는 옵션의 인덱스
+ *
+ * @example
+    export default function CompDropDownOption({
+      children,
+      className,
+      value,
+      selected = false,
+      index,
+      focusedIndex,
+    }: CompDropdownOptionProps) {
+      const { focusedRef } = useFocusOption(focusedIndex, index);
+
+      return (
+        <li
+          ref={focusedRef}
+          className={`${className} ${selected ? 'bg-primary-50' : ''}`}
+          value={value}
+          data-value={value}
+          tabIndex={0}
+        >
+          {children}
+        </li>
+      );
+    }
+ */
+export function useFocusOption(focusedIndex: number, index: number) {
+  const focusedRef = useRef<HTMLLIElement>(null);
+
+  useEffect(() => {
+    if (focusedIndex === index) {
+      focusedRef.current?.focus();
+    }
+  }, [focusedIndex, index]);
+
+  return { focusedRef };
+}

--- a/src/hooks/dropdown/useSelectedOption.tsx
+++ b/src/hooks/dropdown/useSelectedOption.tsx
@@ -1,0 +1,62 @@
+import { SelectedOption } from '@/components/shared/dropdown/types';
+import { useState } from 'react';
+
+/**
+ * @function useSelectedOption
+ * @description
+ * 초기 옵션 배열에서 선택된 옵션과 관련된 상태와 핸들러를 관리
+ *
+ * @param initialOptions - 초기 옵션 배열
+ *
+ * @returns
+ * - selectedDataset: 현재 선택된 옵션의 데이터셋 값
+ * - selectedOption: 현재 선택된 옵션 객체
+ * - handleSelected: 옵션을 선택할 때 호출할 핸들러 함수
+ *
+ * @example
+    // 아래와 같은 위치에서 사용
+    const { selectedDataset, selectedOption, handleSelected } = useSelectedOption(initialOptions);
+
+    const { focusedIndex, handleOptionsKey } = useDropdownOptionsKey({
+      options,
+      handleSelected,
+      setIsOpen,
+    });
+
+    useEffect(() => {
+      selectOption(selectedOption);
+    }, [selectedOption]);
+
+    <CompositeDropdown.Panel
+        onClick={handleSelected}
+        handleOptionsKey={handleOptionsKey}
+      >
+        {() =>
+          renderDropdownOptions(
+            options,
+            selectedDataset,
+            focusedIndex,
+          )
+        }
+      </CompositeDropdown.Panel>
+
+ */
+export function useSelectedOption(
+  initialOptions: Array<SelectedOption>,
+) {
+  const [selectedDataset, setSelectedDataset] = useState('');
+  const [selectedOption, setSelectedOption] = useState(
+    initialOptions.find((option) => option.selected) ||
+      initialOptions[0],
+  );
+
+  function handleSelected(value: string) {
+    const selected =
+      initialOptions.find((option) => option.value === value) ||
+      initialOptions[0];
+    setSelectedOption(selected);
+    setSelectedDataset(value);
+  }
+
+  return { selectedDataset, selectedOption, handleSelected };
+}

--- a/src/hooks/dropdown/useSelectedOption.tsx
+++ b/src/hooks/dropdown/useSelectedOption.tsx
@@ -51,6 +51,8 @@ export function useSelectedOption(
   );
 
   function handleSelected(value: string) {
+    if (value === '') return;
+
     const selected =
       initialOptions.find((option) => option.value === value) ||
       initialOptions[0];

--- a/src/utils/dropdown/handleDropdownStatus.ts
+++ b/src/utils/dropdown/handleDropdownStatus.ts
@@ -1,0 +1,40 @@
+/**
+ * @function handleDropdownStatus
+ * @description
+ * - 드롭다운 상태를 처리하는 함수
+ * - 마우스 클릭 또는 키보드 이벤트를 통해 호출
+ *
+ * @param e - 이벤트 객체, 마우스 클릭 또는 키보드 이벤트
+ * @param onClick - 클릭 이벤트 발생 시 호출되는 함수, 인자는 선택된 target의 dataset.value 인자
+ * @param handleOptionsKey - 키보드 이벤트 발생 시 호출, 선택된 target의 이벤트 객체와 dataset.value 인자
+ *
+ * @example
+    <ul 
+      onClick={(e) => handleDropdownStatus(e, onClickHandler, onKeyHandler)} 
+      onKeyDown={(e) => handleDropdownStatus(e, onClickHandler, onKeyHandler)}
+    >
+      {children()}
+    </ul>
+ */
+export function handleDropdownStatus(
+  e:
+    | React.MouseEvent<HTMLUListElement, MouseEvent>
+    | React.KeyboardEvent<HTMLUListElement>,
+  onClick: (value: string) => void,
+  handleOptionsKey: (
+    e: React.KeyboardEvent<HTMLUListElement>,
+    datasetValue: string,
+  ) => void,
+) {
+  const target = e.target as HTMLUListElement;
+  const value = target.dataset.value as string;
+
+  if (e.type === 'click') {
+    onClick(value);
+  } else if (e.type === 'keydown') {
+    handleOptionsKey(
+      e as React.KeyboardEvent<HTMLUListElement>,
+      value,
+    );
+  }
+}

--- a/src/utils/dropdown/handlePanelKey.ts
+++ b/src/utils/dropdown/handlePanelKey.ts
@@ -1,0 +1,21 @@
+/**
+ * @function handlePanelKey
+ * @description 
+ * - Enter 키 입력에 따라 드롭다운 패널의 열림/닫힘 상태를 설정하는 함수
+ *
+ * @param e - 키보드 이벤트 객체
+ * @param onClick - 드롭다운 패널의 Open 상태를 설정하는 함수
+ *
+ *
+ * @example
+    <ul onKeyDown={(e) => handlePanelKey(e, setIsOpen)}>
+      {children()}
+    </ul>
+ */
+export function handlePanelKey(
+  e: React.KeyboardEvent<HTMLUListElement>,
+  onClick: (isEnter: boolean) => void,
+) {
+  const isEnter = e.key === 'Enter';
+  onClick(isEnter);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈> ex) #이슈번호, #이슈번호
#85 #6 

## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 접근성을 위해 마우스 및 키보드 이벤트 대응
  - 상세 내용 TSDoc 확인
  - 탭 키와 엔터키로 Dropdown 컴포넌트 여닫기 및 선택
  - Panel이 열렸을땐 위 아래 방향키로 조절

### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- Dropdown 컴포넌트의 상태를 조절하는 로직의 분리
- 디자인 시안에 없는 UI (ex. hover, selected 된 상태 및 Panel을 여닫는 액션)
