### PR TITLE
[#138] 주식 상세페이지 UI 구현

### DIFF
--- a/src/app/(after)/stock/[stockId]/page.tsx
+++ b/src/app/(after)/stock/[stockId]/page.tsx
@@ -1,0 +1,20 @@
+import NewsHeading from '@/components/news/NewsHeading';
+import NewsSection from '@/components/news/NewsSection';
+import TodayPopularNews from '@/components/news/TodayPopularNews';
+import SkeletonTodayPopularNews from '@/components/skeleton/news/SkeletonTodayPopularNews';
+import ChartSection from '@/components/stock/detail/ChartSection';
+import { Suspense } from 'react';
+
+export default function StockDetail() {
+  return (
+    <div className="flex flex-col gap-5">
+      <ChartSection />
+      <NewsSection>
+        <NewsHeading>오늘 인기있는 뉴스</NewsHeading>
+        <Suspense fallback={<SkeletonTodayPopularNews />}>
+          <TodayPopularNews />
+        </Suspense>
+      </NewsSection>
+    </div>
+  );
+}

--- a/src/components/shared/chart/ChartMain.tsx
+++ b/src/components/shared/chart/ChartMain.tsx
@@ -2,8 +2,14 @@ import Wrapper from '../Wrapper';
 
 export default function ChartMain({
   children,
+  width = '',
 }: {
   children: React.ReactNode;
+  width?: string;
 }) {
-  return <Wrapper padding="px-8 pt-8">{children}</Wrapper>;
+  return (
+    <Wrapper width={width} padding="px-8 pt-8">
+      {children}
+    </Wrapper>
+  );
 }

--- a/src/components/shared/chart/StockAIReportCard.tsx
+++ b/src/components/shared/chart/StockAIReportCard.tsx
@@ -6,10 +6,10 @@ import Rechart from './rechart';
 const radarStatus = {
   width: 189.43,
   height: 176,
-  cx: 88,
+  cx: 80,
   cy: 93,
-  outerRadius: 93,
-  polarRadius: [35, 50, 65, 80, 95],
+  outerRadius: 84,
+  polarRadius: [25, 40, 55, 70, 85],
   numberOfSides: 5,
 };
 
@@ -49,15 +49,22 @@ const radarData = [
 /**
  * 프롬프트 작업 대기, 임시 완성
  */
-export default function StockAIReportCard() {
+export default function StockAIReportCard({
+  as,
+}: {
+  as: React.ElementType;
+}) {
   const score = 70;
 
   return (
     <Rechart className={'min-w-[365.44px] pb-8'}>
       <div className="flex justify-between pr-[8.439px] mb-[17px]">
-        <Rechart.RadarLabel className="b1 font-semibold text-primary-900">
+        <Rechart.Label
+          as={as}
+          className="b1 font-semibold text-primary-900"
+        >
           종목 AI 리포트
-        </Rechart.RadarLabel>
+        </Rechart.Label>
         <Rechart.RadarScore className="h3 font-medium text-grayscale-700">
           {score}점
         </Rechart.RadarScore>

--- a/src/components/shared/chart/StockAIReportChart.tsx
+++ b/src/components/shared/chart/StockAIReportChart.tsx
@@ -13,7 +13,7 @@ export default function StockAIReportChart({
   specific?: boolean;
 }) {
   return (
-    <div className={`flex gap-[13.43px] justify-between w-full`}>
+    <div className={`flex justify-between w-full`}>
       <Rechart.Radar radarStatus={radarStatus} data={radarData}>
         {children}
       </Rechart.Radar>

--- a/src/components/shared/chart/StockChartCard.tsx
+++ b/src/components/shared/chart/StockChartCard.tsx
@@ -1,0 +1,37 @@
+import Rechart from './rechart';
+import AreaBtn from './rechart/AreaBtn';
+
+export default function StockChartCard({
+  as,
+}: {
+  as: React.ElementType;
+}) {
+  return (
+    <Rechart>
+      <div className="flex items-center justify-between pr-[8.439px] mb-[17px]">
+        <Rechart.Label
+          as={as}
+          className="b1 font-semibold text-primary-900"
+        >
+          주가 차트
+        </Rechart.Label>
+        <Rechart.AreaBtnWrapper className="flex items-center">
+          <AreaBtn duration={{ amount: 1, unit: 'day' }}>1일</AreaBtn>
+          <AreaBtn duration={{ amount: 3, unit: 'month' }}>
+            3개월
+          </AreaBtn>
+          <AreaBtn duration={{ amount: 1, unit: 'year' }}>
+            1년
+          </AreaBtn>
+          <AreaBtn duration={{ amount: 3, unit: 'year' }}>
+            3년
+          </AreaBtn>
+          <AreaBtn duration={{ amount: 10, unit: 'year' }}>
+            10년
+          </AreaBtn>
+        </Rechart.AreaBtnWrapper>
+      </div>
+      <Rechart.Area />
+    </Rechart>
+  );
+}

--- a/src/components/shared/chart/index.tsx
+++ b/src/components/shared/chart/index.tsx
@@ -1,9 +1,11 @@
 import ChartMain from './ChartMain';
 import SpecificStockAIReport from './SpecificStockAIReport';
 import StockAIReportCard from './StockAIReportCard';
+import StockChartCard from './StockChartCard';
 
 export const Chart = Object.assign(ChartMain, {
   SpecificStockAIReport,
   StockAIReportCard,
+  StockChartCard,
 });
 export default Chart;

--- a/src/components/shared/chart/rechart/AreaBtn.tsx
+++ b/src/components/shared/chart/rechart/AreaBtn.tsx
@@ -1,0 +1,36 @@
+import { useSearchParams } from 'next/navigation';
+import ButtonBase from '../../buttons/ButtonBase';
+import { Duration } from '../types';
+import { useRouteAreaChart } from '@/hooks/useRouteAreaChart';
+
+export default function AreaBtn({
+  children,
+  className,
+  duration,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  duration: Duration;
+}) {
+  const { handleRoute } = useRouteAreaChart();
+  const searchParams = useSearchParams();
+  const amount = Number(searchParams.get('amount'));
+  const unit = searchParams.get('unit');
+  const selected =
+    amount === duration.amount && unit === duration.unit;
+
+  return (
+    <li className={className}>
+      <ButtonBase
+        className={`b5 font-medium ${
+          selected
+            ? 'bg-primary-50 text-primary-900'
+            : 'bg-grayscale-0 text-grayscale-400'
+        } rounded-lg py-[6px] px-[22.5px]`}
+        onClick={() => handleRoute(duration)}
+      >
+        {children}
+      </ButtonBase>
+    </li>
+  );
+}

--- a/src/components/shared/chart/rechart/AreaBtnWrapper.tsx
+++ b/src/components/shared/chart/rechart/AreaBtnWrapper.tsx
@@ -1,0 +1,9 @@
+export default function AreaBtnWrapper({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <ul className={className}>{children}</ul>;
+}

--- a/src/components/shared/chart/rechart/AreaChartCore.tsx
+++ b/src/components/shared/chart/rechart/AreaChartCore.tsx
@@ -1,52 +1,68 @@
 import { dynamicImport } from '@/utils/rechart/dynamicRecharts';
 import { Area, XAxis, YAxis, Tooltip } from 'recharts';
+import { CustomizedXAxisTickProps } from '../types';
 
 const DynamicAreaChart = dynamicImport('AreaChart');
 
 const data = [
   {
-    name: 'Page A',
-    uv: 4000,
+    name: '2024/04',
+    uv: 1000,
     pv: 2400,
     amt: 2400,
   },
   {
-    name: 'Page B',
+    name: '2024/05',
     uv: 3000,
     pv: 1398,
     amt: 2210,
   },
   {
-    name: 'Page C',
+    name: '2024/06',
     uv: 2000,
     pv: 9800,
     amt: 2290,
   },
   {
-    name: 'Page D',
-    uv: 2780,
-    pv: 3908,
-    amt: 2000,
+    name: '2024/07',
+    uv: 9000,
+    pv: 9800,
+    amt: 2290,
   },
   {
-    name: 'Page E',
-    uv: 1890,
-    pv: 4800,
-    amt: 2181,
-  },
-  {
-    name: 'Page F',
-    uv: 2390,
-    pv: 3800,
-    amt: 2500,
-  },
-  {
-    name: 'Page G',
-    uv: 3490,
-    pv: 4300,
-    amt: 2100,
+    name: '2024/08',
+    uv: 4000,
+    pv: 9800,
+    amt: 2290,
   },
 ];
+const lastDataName = data[data.length - 1].name;
+const renderCustomizedXAxisTick = (
+  props: CustomizedXAxisTickProps,
+  lastDataName: string | number,
+) => {
+  const { x, y, payload } = props;
+  const isSpecificLabel = payload.value === lastDataName;
+
+  return (
+    <g
+      transform={`translate(${
+        x + (isSpecificLabel ? 150 : 0)
+      }, ${y})`}
+    >
+      <text
+        x={0}
+        y={0}
+        dy={5}
+        textAnchor="middle"
+        fill="#9F9F9F"
+        fontSize={12}
+      >
+        {payload.value}
+      </text>
+    </g>
+  );
+};
 
 /**
  *
@@ -56,24 +72,45 @@ const data = [
 export default function AreaChartCore() {
   return (
     <DynamicAreaChart
-      width={600}
-      height={400}
+      width={617}
+      height={152}
       data={data}
       margin={{
         top: 5,
-        right: 0,
+        right: 11,
         left: 0,
-        bottom: 5,
+        bottom: 0,
       }}
     >
       <defs>
         <linearGradient id="colorUv" x1="0" y1="0" x2="0" y2="1">
           <stop offset="30%" stopColor="#00ACF2" stopOpacity={0.7} />
-          <stop offset="100%" stopColor="#00ACF2" stopOpacity={0} />
+          <stop
+            offset="100%"
+            stopColor="#00ACF2"
+            stopOpacity={0.07}
+          />
         </linearGradient>
       </defs>
-      <XAxis dataKey="name" axisLine={false} tickLine={false} />
-      <YAxis orientation="right" axisLine={false} tickLine={false} />
+      <XAxis
+        dataKey="name"
+        axisLine={false}
+        tickLine={false}
+        tick={(props) =>
+          renderCustomizedXAxisTick(props, lastDataName)
+        }
+      />
+      <YAxis
+        orientation="right"
+        axisLine={false}
+        tickLine={false}
+        tick={{
+          fill: '#9F9F9F',
+          fontSize: 14,
+          textAnchor: 'middle',
+          dx: 30,
+        }}
+      />
       <Tooltip />
       <Area
         type="monotone"

--- a/src/components/shared/chart/rechart/ChartLabel.tsx
+++ b/src/components/shared/chart/rechart/ChartLabel.tsx
@@ -1,0 +1,11 @@
+export default function ChartLabel({
+  as: Tag = 'div',
+  children,
+  className,
+}: {
+  as?: React.ElementType;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <Tag className={className}>{children}</Tag>;
+}

--- a/src/components/shared/chart/rechart/RadarLabel.tsx
+++ b/src/components/shared/chart/rechart/RadarLabel.tsx
@@ -1,9 +1,0 @@
-export default function RadarLabel({
-  children,
-  className,
-}: {
-  children: React.ReactNode;
-  className?: string;
-}) {
-  return <div className={className}>{children}</div>;
-}

--- a/src/components/shared/chart/rechart/index.tsx
+++ b/src/components/shared/chart/rechart/index.tsx
@@ -1,23 +1,25 @@
 import AreaChart from './AreaChartCore';
 import RechartMain from './RechartMain';
 import StockAIReportCore from './StockAIReportCore';
-import RadarLabel from './RadarLabel';
+import ChartLabel from './ChartLabel';
 import RadarMetricsBox from './RadarMetricsBox';
 import RadarScore from './RadarScore';
 import RadarMetrics from './RadarMetrics';
 import RadarBtnWrapper from './RadarBtnWrapper';
 import MetricsLabel from './MetricsLabel';
 import MetricsPercent from './MetricsPercent';
+import AreaBtnWrapper from './AreaBtnWrapper';
 
 export const Rechart = Object.assign(RechartMain, {
   Area: AreaChart,
   Radar: StockAIReportCore,
-  RadarLabel,
+  Label: ChartLabel,
   RadarMetricsBox,
   RadarScore,
   RadarMetrics,
   RadarBtnWrapper,
   MetricsLabel,
   MetricsPercent,
+  AreaBtnWrapper,
 });
 export default Rechart;

--- a/src/components/shared/chart/types.ts
+++ b/src/components/shared/chart/types.ts
@@ -38,3 +38,19 @@ export type RadarData = Array<{
   B: number;
   fullMark: number;
 }>;
+
+export type Duration = {
+  amount: number;
+  unit: 'day' | 'month' | 'year';
+};
+
+export type CustomizedXAxisTickProps = {
+  x: number;
+  y: number;
+  payload: {
+    value: string | number;
+    coordinate: number;
+    index: number;
+  };
+  index: number;
+};

--- a/src/components/stock/RequestWrapper.tsx
+++ b/src/components/stock/RequestWrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import AddInterest from './AddInterest';
+import ThatGoAddInterest from './ThatGoAddInterest';
 import ShowingInterest from './ShowingInterest';
 import { useInView } from 'react-intersection-observer';
 
@@ -62,7 +62,7 @@ export default function RequestWrapper() {
 
   return (
     <>
-      <AddInterest />
+      <ThatGoAddInterest />
       <ShowingInterest stocks={stocks} isLoading={isLoading} />
       <span ref={ref} />
     </>

--- a/src/components/stock/ThatGoAddInterest.tsx
+++ b/src/components/stock/ThatGoAddInterest.tsx
@@ -1,6 +1,6 @@
 import ButtonBase from '../shared/buttons/ButtonBase';
 
-export default function AddInterest() {
+export default function ThatGoAddInterest() {
   const name = '최석호';
 
   return (

--- a/src/components/stock/detail/AddInterest.tsx
+++ b/src/components/stock/detail/AddInterest.tsx
@@ -1,0 +1,35 @@
+import StockIcon from '@/components/shared/StockIcon';
+import ButtonBase from '@/components/shared/buttons/ButtonBase';
+
+export default function AddInterest() {
+  const isInterest = false;
+  return (
+    <div className="flex justify-between mb-[27px]">
+      {/* 임시 구현 - Icon 컴포넌트 담당 한승재 (stat1202) */}
+      <div className="flex items-center gap-2">
+        <StockIcon
+          path={
+            'https://zlxqxgiycccjxcwzonsx.supabase.co/storage/v1/object/public/8b-sf/stock_logo/apple_logo.svg'
+          }
+          size="small"
+        />
+        <div className="flex gap-2 items-center b2 font-medium">
+          <h2 className="b1 font-bold">애플</h2>
+          <span>∙</span>
+          <span className="b3 font-normal">AAPL</span>
+        </div>
+      </div>
+      <ButtonBase
+        className={`box-border b4 font-normal rounded-lg border border-primary-900 min-w-[167px] py-4 px-10 hover:bg-opacity-90 
+        active:bg-opacity-95 ${
+          isInterest ? 'text-primary-900' : 'text-grayscale-0'
+        } bg-primary-900 ${
+          isInterest ? 'bg-opacity-0' : 'bg-opacity-100'
+        } 
+hover:opacity-90 active:opacity-95`}
+      >
+        관심종목 {isInterest ? '해제' : '추가'}
+      </ButtonBase>
+    </div>
+  );
+}

--- a/src/components/stock/detail/ChartSection.tsx
+++ b/src/components/stock/detail/ChartSection.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import Chart from '@/components/shared/chart';
+import AddInterest from './AddInterest';
+import Wrapper from '@/components/shared/Wrapper';
+import ToggleButton from '@/components/shared/ToggleButton';
+import StockIcon from '@/components/shared/StockIcon';
+
+export default function ChartSection() {
+  return (
+    <>
+      <AddInterest />
+      <div className="flex justify-between">
+        <Wrapper width="w-[488px]" padding="p-8">
+          {/* 임시 구현 - Icon 컴포넌트 담당 한승재 (stat1202) */}
+          <div className="flex justify-between mb-8">
+            <div>
+              <div className="flex items-center gap-[2px]">
+                <span className="b1 font-bold text-primary-900">
+                  $00.00
+                </span>
+                <span className="b2 font-normal text-primary-900">
+                  ∙
+                </span>
+                <span className="b2 font-normal text-primary-900">
+                  AAPL
+                </span>
+              </div>
+              <span className="b2 font-medium text-warning-100">
+                ▲1.75 +0.82%
+              </span>
+            </div>
+            <ToggleButton />
+          </div>
+          <p className="b4 font-normal text-grayscale-900">
+            애플은 스마트폰, 개인용 컴퓨터, 태블릿, 웨어러블 및
+            액세서리를 설계, 제조 및 판매하고 다양한 관련 서비스를
+            판매한다. 제품 카테고리는 iPhone, MAc, iPad, Wearables,
+            Home 및 Accessories로 나뉜다.
+          </p>
+        </Wrapper>
+        <Chart width="min-w-[692px]">
+          <Chart.StockChartCard as="h3" />
+        </Chart>
+      </div>
+      <div className="flex justify-between box-border">
+        <Chart>
+          <Chart.StockAIReportCard as="h3" />
+        </Chart>
+        <Wrapper width="w-[750px]" padding="p-8">
+          <h3 className="b1 font-bold text-primary-900 mb-[55px]">
+            아잇나우 AI 애널리스트 리포트
+          </h3>
+
+          {/* 임시 구현 - Icon 컴포넌트 담당 한승재 (stat1202) */}
+          <div className="flex items-center gap-2 mb-4">
+            <StockIcon
+              path={
+                'https://zlxqxgiycccjxcwzonsx.supabase.co/storage/v1/object/public/8b-sf/stock_logo/apple_logo.svg'
+              }
+              size="small"
+            />
+            <div className="flex gap-2 items-center b2 font-medium">
+              <h2 className="b3 font-medium text-grayscale-900">
+                애플
+              </h2>
+              <span>∙</span>
+              <span className="b3 font-normal text-grayscale-900">
+                AAPL
+              </span>
+              <span className="b4 font-medium text-grayscale-900">
+                $00.00
+              </span>
+              <span className="b4 font-normal text-warning-100">
+                ▲1.75 +0.82%
+              </span>
+            </div>
+          </div>
+          <p className="b4 font-medium text-[#000000]">
+            급격한 금리 인상에도 견조한 자동차 수요를 반영하여
+            테슬라의 목표주가를 340달러로 26% 상향 조정하고 Top
+            Pick으로 유지한다. 단기 상승에 따른 숨 고르기가
+            예상되지만, 중기적으로 동사의 경쟁우위는 더 강해지고 있다.
+          </p>
+        </Wrapper>
+      </div>
+    </>
+  );
+}

--- a/src/hooks/useRouteAreaChart.tsx
+++ b/src/hooks/useRouteAreaChart.tsx
@@ -1,0 +1,14 @@
+import { Duration } from '@/components/shared/chart/types';
+import { useRouter } from 'next/navigation';
+
+export function useRouteAreaChart() {
+  const router = useRouter();
+
+  function handleRoute(duration: Duration) {
+    console.log(duration);
+    const { amount, unit } = duration;
+    router.push(`?amount=${amount}&unit=${unit}`);
+  }
+
+  return { handleRoute };
+}


### PR DESCRIPTION
## #️⃣연관된 이슈> ex) #이슈번호, #이슈번호
#1 #32 #110

## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
![stock-detail-gif](https://github.com/NextCamp-8B/8B-SF/assets/126848879/34db54ac-46f6-481a-b160-0e4bf335fe67)
- 주식 상세 페이지 UI 구현
- 디자이너님 소통 후 AreaChart 디자인 임의 수정
  - Y 축이라 의심됐던 기간 버튼 우측 상단으로 이동
  - 새로고침 시 탭 활성화 유지를 위한 쿼리 스트링 사용 
- Chart 컴포넌트 수정
  - 유연한 h Tag 시리즈 활용을 위한 as prop 추가
  - UI 수치 조정
  - AreaChart x축 마지막 XAxis 조정을 위한 svg 오버라이드
  - Icon 관련 임시 구현

### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ChartSection, AddInterest 컴포넌트의 Icon 관련 코드
  - 담당자 한승재 (@stat1202 ) 주석 표시 
  - 디스코드 소통 결과 프롬프트, API 데이터 작업 후 수정 예정
