### PR TITLE
[#159] HttpClient 및 AightnowClient 구현

### DIFF
--- a/src/app/(tmp)/csh/page.tsx
+++ b/src/app/(tmp)/csh/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { lLMAPI } from '@/service/apiInstance';
+import { useState } from 'react';
+
+const message = `As a stock analyst, you are an agent who gives
+    stock-related information on behalf of customers when they want
+     to obtain information such as stock-related information, current 
+     status, or statistics. If there are any stock-related terms 
+     to answer a question, you should put the term description below the answ
+     \n\nquestion: 너가 생각하기에 하이닉스의 재무재표 분석하고, 투자하기 좋아보이는지 
+     판단하고 상, 중, 하 중에 하나로 대답해줘.`;
+
+/** 의도한 console 입니다. */
+export default function page() {
+  const [state, setState] = useState();
+  /** 서버 api 테스트 */
+  // const serverTest = await lLMAPI.loginLLM({ isServer: true });
+  // console.log(serverTest);
+
+  /** 클라이언트 api 테스트 */
+  const loginLLMTest = async () => {
+    await lLMAPI.loginLLM();
+  };
+
+  const req = {
+    userMessage: message,
+    temperature: 0,
+    topP: 0,
+  };
+  const generateTest = async () => {
+    const m = await lLMAPI.generatePrompt({
+      req,
+    });
+    setState(m);
+  };
+
+  return (
+    <div>
+      <button onClick={generateTest}>Generate</button>
+      <p>{state}</p>
+    </div>
+  );
+}

--- a/src/app/api/llm-prompt/auth/route.ts
+++ b/src/app/api/llm-prompt/auth/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const authURL = `${process.env.LLAMA_API_URL}auth/token`;
+  const authBody = {
+    username: `${process.env.LLAMA_USER_NAME}`,
+    password: `${process.env.LLAMA_PASSWORD}`,
+  };
+
+  const param = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams(authBody),
+  };
+
+  const response = await fetch(authURL, param);
+  const authData = await response.json();
+
+  return NextResponse.json(authData);
+}

--- a/src/app/api/llm-prompt/generate/route.ts
+++ b/src/app/api/llm-prompt/generate/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { userMessage, temperature, topP } = await req.json();
+  const authorizationHeader = req.headers.get('authorization');
+  const authorization = authorizationHeader?.startsWith('Bearer ')
+    ? authorizationHeader
+    : `Bearer ${authorizationHeader}`;
+
+  const generateURL = `${process.env.LLAMA_API_URL}generate`;
+  const generateBody = {
+    user_message: userMessage,
+    temperature: temperature,
+    top_p: topP,
+  };
+  const generateResponse = await fetch(generateURL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: authorization,
+    },
+    body: JSON.stringify(generateBody),
+  });
+
+  if (!generateResponse.ok) {
+    const errorData = await generateResponse.json();
+    return NextResponse.json(
+      { error: 'Generation failed', details: errorData },
+      { status: generateResponse.status },
+    );
+  }
+
+  const reader = generateResponse.body!.getReader();
+  const decoder = new TextDecoder('utf-8');
+  const answer = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    answer.push(decoder.decode(value, { stream: true }));
+  }
+
+  answer.push(decoder.decode());
+
+  return NextResponse.json(answer.join(''));
+}

--- a/src/service/aightnowClient.ts
+++ b/src/service/aightnowClient.ts
@@ -1,0 +1,53 @@
+import { GenerationRequest } from './serviceType';
+import HttpClient from './httpClient';
+
+export default class AightnowClient {
+  constructor(private httpClient: HttpClient) {
+    this.loginLLM = this.loginLLM.bind(this);
+  }
+
+  async loginLLM({ isServer = false }: { isServer?: boolean } = {}) {
+    const authURL = `api/llm-prompt/auth`;
+    const { token_type: type, access_token: lLMAccessToken } =
+      await this.httpClient.get({ url: authURL, isServer });
+
+    /** 토큰 - 스토리지 임시 저장 */
+    const llMBearerToken = `Bearer ${lLMAccessToken}`;
+    // const llMBearerToken = `${type} ${lLMAccessToken}`;
+    if (!isServer) {
+      localStorage.setItem('llMBearerToken', llMBearerToken);
+    }
+
+    return llMBearerToken;
+  }
+
+  async generatePrompt({
+    req,
+    isServer = false,
+  }: {
+    req: GenerationRequest;
+    isServer?: boolean;
+  }) {
+    const { userMessage, temperature, topP } = req;
+    const authURL = `api/llm-prompt/generate`;
+    /** 토큰 - 임시 사용 */
+    const llMBearerToken = localStorage.getItem('llMBearerToken');
+
+    const generateBody = {
+      userMessage,
+      temperature,
+      topP,
+    };
+
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: `${llMBearerToken}`,
+    };
+
+    return this.httpClient.post({
+      url: authURL,
+      headers,
+      body: generateBody,
+    });
+  }
+}

--- a/src/service/apiInstance.ts
+++ b/src/service/apiInstance.ts
@@ -1,0 +1,10 @@
+import AightnowClient from './aightnowClient';
+import HttpClient from './httpClient';
+
+const businessClient = new HttpClient(`${process.env.NEXTAUTH_URL}`);
+const lLMlient = new HttpClient(`${process.env.NEXTAUTH_URL}`);
+
+const businessAPI = new AightnowClient(businessClient);
+const lLMAPI = new AightnowClient(lLMlient);
+
+export { businessAPI, lLMAPI };

--- a/src/service/httpClient.ts
+++ b/src/service/httpClient.ts
@@ -1,0 +1,113 @@
+import { OmittedHTTPMethod, RequestOptions } from './serviceType';
+
+export default class HttpClient {
+  private baseURL: string;
+
+  constructor(baseURL: string) {
+    this.baseURL = baseURL;
+  }
+
+  private async makeRequest<BodyType>(
+    config: RequestOptions<BodyType>,
+  ): Promise<any> {
+    const { url, method, headers, body, isServer } = config;
+    /** 내부 API 요청인지 확인 */
+    // const isInternalApi = url.startsWith('api/');
+
+    const requestUrl = isServer ? `${this.baseURL}${url}` : url;
+    const options: RequestInit = {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...headers,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    };
+
+    try {
+      const response = await fetch(requestUrl, options);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error(`Error with ${method} request to ${url}:`, error);
+      throw error;
+    }
+  }
+
+  async get({
+    url,
+    headers = {},
+    isServer = false,
+  }: Pick<
+    OmittedHTTPMethod,
+    'url' | 'headers' | 'isServer'
+  >): Promise<any> {
+    return this.makeRequest({
+      url,
+      method: 'GET',
+      headers,
+      isServer,
+    });
+  }
+
+  async post({
+    url,
+    body,
+    headers = {},
+    isServer = false,
+  }: OmittedHTTPMethod): Promise<any> {
+    return this.makeRequest({
+      url,
+      method: 'POST',
+      headers,
+      body,
+      isServer,
+    });
+  }
+
+  async put({
+    url,
+    body,
+    headers = {},
+    isServer = false,
+  }: OmittedHTTPMethod): Promise<any> {
+    return this.makeRequest({
+      url,
+      method: 'PUT',
+      headers,
+      body,
+      isServer,
+    });
+  }
+
+  async patch({
+    url,
+    body,
+    headers = {},
+    isServer = false,
+  }: OmittedHTTPMethod): Promise<any> {
+    return this.makeRequest({
+      url,
+      method: 'PATCH',
+      headers,
+      body,
+      isServer,
+    });
+  }
+
+  async deleteRequest({
+    url,
+    headers = {},
+    isServer = false,
+  }: Omit<OmittedHTTPMethod, 'body'>): Promise<any> {
+    return this.makeRequest({
+      url,
+      method: 'DELETE',
+      headers,
+      isServer,
+    });
+  }
+}

--- a/src/service/serviceType.ts
+++ b/src/service/serviceType.ts
@@ -1,0 +1,19 @@
+interface HTTPParamType<BodyType = any> {
+  url: string;
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  headers?: Record<string, string>;
+  body?: BodyType;
+  isServer?: boolean;
+}
+
+export interface RequestOptions<BodyType = any>
+  extends HTTPParamType<BodyType> {}
+
+export type OmittedHTTPMethod = Omit<HTTPParamType, 'method'>;
+export type OmittedHTTPURL = Omit<HTTPParamType, 'url'>;
+
+export interface GenerationRequest {
+  userMessage: string;
+  temperature: number;
+  topP: number;
+}


### PR DESCRIPTION
## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- HttpClient
  - HTTP 요청 인터페이스
  - Aightnow의 비즈니스 로직 분리 
- AightnowClient 
  - HTTP 요청 인터페이스
  - Aightnow의 비즈니스 로직 포함
- Llama3 로그인 및 프롬프트 API 추가 (테스트 위함)
  - GPT4 변경 논의중 

### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- ReactJS에서처럼 Context API 와 Custom Hook 사용 시 전체가 Client Component가 되는 문제점 발견
- NextJS에서 HTTP 인터페이스 관련 학습 필요
