### PR TITLE
[#179] 최근 검색 종목 API 로직 구현

### DIFF
--- a/src/app/api/search/recent/route.ts
+++ b/src/app/api/search/recent/route.ts
@@ -47,14 +47,13 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   const supabase = createClient();
 
-  const { stock_id, session } = await request.json();
-  const userId = session.user.id;
+  const { stockId, userId } = await request.json();
 
   const { data: existingData, error: selectError } = await supabase
     .from('recent_search_stocks')
     .select('*')
     .eq('id', userId)
-    .eq('stock_id', stock_id)
+    .eq('stock_id', stockId)
     .single();
 
   if (existingData !== null) {
@@ -63,7 +62,7 @@ export async function POST(request: Request) {
       .from('recent_search_stocks')
       .update({ created_at: new Date().toISOString() })
       .eq('id', userId)
-      .eq('stock_id', stock_id);
+      .eq('stock_id', stockId);
 
     return new Response(JSON.stringify({ updateData }), {
       status: 200,
@@ -73,7 +72,7 @@ export async function POST(request: Request) {
   else {
     const { data: insertData, error: insertError } = await supabase
       .from('recent_search_stocks')
-      .insert([{ id: userId, stock_id }]);
+      .insert([{ id: userId, stock_id: stockId }]);
 
     return new Response(JSON.stringify({ insertData }), {
       status: 200,
@@ -89,7 +88,6 @@ export async function DELETE(request: Request) {
   const stockId = url.searchParams.get('stockId');
   let result;
 
-  console.log(type, userId, stockId);
   if (type === 'all') {
     // userId가 일치하는 모든 데이터 삭제
     const { data, error } = await supabase

--- a/src/components/search/DeleteSearch.tsx
+++ b/src/components/search/DeleteSearch.tsx
@@ -1,35 +1,39 @@
-'use client';
-
 import Close from '@/assets/icons/close.svg';
 import { stocksProps } from './InputItem';
+import { UUID } from 'crypto';
+import { businessAPI } from '@/service/apiInstance';
 
 export default function DeleteSearch({
-  type,
-  data,
-  session,
+  type = 'all',
+  stockId,
+  userId,
   setRecentDatas,
 }: {
-  type: 'all' | 'select';
-  data?: stocksProps | null;
-  session: any;
+  type?: 'all' | 'select';
+  stockId?: UUID;
+  userId: UUID;
   setRecentDatas: (data: stocksProps[] | null) => void;
 }) {
-  const deleteStock = async () => {
-    let url = `/api/search/recent?type=${type}&userId=${session.id}`;
+  const { deleteRecentSearch, getRecentSearch } = businessAPI;
+  const deleteSerachStock = async ({
+    type = 'all',
+    userId,
+    stockId,
+  }: {
+    type?: 'all' | 'select';
+    userId: UUID;
+    stockId?: UUID | undefined;
+  }) => {
+    const response = await deleteRecentSearch({
+      type,
+      userId,
+      stockId,
+    });
+    const { success } = response;
 
-    if (type === 'select' && data) {
-      url += `&stockId=${data.stock_id}`;
-    }
-
-    const response = await fetch(url, { method: 'DELETE' });
-    if (response.ok) {
-      const updatedResponse = await fetch(
-        `/api/search/recent?userId=${session.id}`,
-      );
-      if (updatedResponse.ok) {
-        const updatedData = await updatedResponse.json();
-        setRecentDatas(updatedData.stocks);
-      }
+    if (success) {
+      const { stocks } = await getRecentSearch({ userId });
+      setRecentDatas(stocks);
     }
   };
 
@@ -38,13 +42,17 @@ export default function DeleteSearch({
       {type === 'all' && (
         <button
           className="text-grayscale-600 font-medium text-md underline"
-          onClick={() => deleteStock()}
+          onClick={() => deleteSerachStock({ userId })}
         >
           전체삭제
         </button>
       )}
       {type === 'select' && (
-        <div onClick={() => deleteStock()}>
+        <div
+          onClick={() =>
+            deleteSerachStock({ type: 'select', userId, stockId })
+          }
+        >
           <Close width={24} height={24} />
         </div>
       )}

--- a/src/components/search/FindStock.tsx
+++ b/src/components/search/FindStock.tsx
@@ -3,15 +3,16 @@
 import { useEffect, useState } from 'react';
 import FindStockItem from './FindStockItem';
 import FindNews from '../search/FindNews';
-import { TMP_NEWS_LIST } from '@/constants';
 import { Stock } from '@/types/stock';
 import { News } from '@/types/news';
-import { useSession } from 'next-auth/react';
+import { Session } from 'next-auth';
 
 export default function FindStock({
   searchText,
+  session,
 }: {
   searchText: string;
+  session: Session | null;
 }) {
   const [stocksList, setStocksList] = useState<Stock[]>([]);
   const [newsList, setNewsList] = useState<News[]>([]);
@@ -33,7 +34,6 @@ export default function FindStock({
 
     return () => clearTimeout(debounceTimeout);
   }, [searchText]);
-  const { data: session, status } = useSession();
 
   useEffect(() => {
     const fetchNews = async () => {

--- a/src/components/search/InputItem.tsx
+++ b/src/components/search/InputItem.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { useCallback, useEffect, useState } from 'react';
 import FindStock from './FindStock';
 import RecentSearch from './RecentSearch';
@@ -13,17 +14,18 @@ export type stocksProps = {
   created_at?: string;
 };
 
-export default function InputItem({}: {}) {
-  const { data: session, status } = useSession();
+export default function InputItem() {
   const [text, setText] = useState('');
   const [recentDatas, setRecentDatas] = useState<
     stocksProps[] | null
   >([]);
+  const { data: session, status } = useSession();
+  const isAuthenticated = status === 'authenticated';
 
   const fetchRecentSearch = useCallback(async () => {
-    if (session) {
+    if (isAuthenticated) {
       const response = await fetch(
-        `/api/search/recent?userId=${session?.user.id}`,
+        `/api/search/recent?userId=${session?.user?.id || ''}`,
       );
       if (response.ok) {
         const data = await response.json();
@@ -48,7 +50,7 @@ export default function InputItem({}: {}) {
       />
 
       {text.trim().length > 0 ? (
-        <FindStock searchText={text} />
+        <FindStock searchText={text} session={session} />
       ) : (
         <>
           <div className="py-4">

--- a/src/components/search/RecentSearch.tsx
+++ b/src/components/search/RecentSearch.tsx
@@ -1,10 +1,11 @@
 import Time from '@/assets/icons/time.svg';
-import Link from 'next/link';
 import { searchDate } from '@/utils/date';
 import DeleteSearch from './DeleteSearch';
 import SearchHeading from './SearchHeading';
 import SearchLabel from './SearchLabel';
 import { stocksProps } from './InputItem';
+import { Session } from 'next-auth';
+import { UUID } from 'crypto';
 
 export default function RecentSearch({
   recentDatas,
@@ -12,16 +13,18 @@ export default function RecentSearch({
   setRecentDatas,
 }: {
   recentDatas: stocksProps[] | null;
-  session: any;
+  session: Session | null;
   setRecentDatas: (data: stocksProps[] | null) => void;
 }) {
+  const { user } = session || { user: null };
+
   return (
     <div className="w-[590px]">
       <div className="flex items-center justify-between">
         <SearchHeading> 최근 검색어</SearchHeading>
         <DeleteSearch
           type="all"
-          session={session.user}
+          userId={user?.id as UUID}
           setRecentDatas={setRecentDatas}
         />
       </div>
@@ -46,8 +49,8 @@ export default function RecentSearch({
                   <button type="submit">
                     <DeleteSearch
                       type="select"
-                      session={session.user}
-                      data={recentData}
+                      userId={user?.id as UUID}
+                      stockId={recentData?.stock_id as UUID}
                       setRecentDatas={setRecentDatas}
                     />
                   </button>

--- a/src/service/aightnowClient.ts
+++ b/src/service/aightnowClient.ts
@@ -1,9 +1,13 @@
 import { GenerationRequest } from './serviceType';
 import HttpClient from './httpClient';
+import { UUID } from 'crypto';
 
 export default class AightnowClient {
   constructor(private httpClient: HttpClient) {
     this.loginLLM = this.loginLLM.bind(this);
+    this.generatePrompt = this.generatePrompt.bind(this);
+    this.updateRecentSearch = this.updateRecentSearch.bind(this);
+    this.deleteRecentSearch = this.deleteRecentSearch.bind(this);
   }
 
   async loginLLM({ isServer = false }: { isServer?: boolean } = {}) {
@@ -48,6 +52,24 @@ export default class AightnowClient {
       url: authURL,
       headers,
       body: generateBody,
+    });
+  }
+
+  async updateRecentSearch({
+    userId,
+    stockId,
+  }: {
+    userId: UUID;
+    stockId: UUID;
+  }) {
+    const nextURL = `/api/search/recent`;
+
+    return this.httpClient.post({
+      url: nextURL,
+      body: {
+        userId,
+        stockId,
+      },
     });
   }
 }

--- a/src/service/aightnowClient.ts
+++ b/src/service/aightnowClient.ts
@@ -72,4 +72,25 @@ export default class AightnowClient {
       },
     });
   }
+
+  async deleteRecentSearch({
+    type = 'all',
+    userId,
+    stockId,
+  }: {
+    type?: string;
+    userId: UUID;
+    stockId?: UUID | undefined;
+  }) {
+    const nextURL = `/api/search/recent?type=${type}&userId=${userId}`;
+    const isAll = type === 'all';
+
+    if (!isAll) {
+      nextURL.concat('', `&stockId=${stockId}`);
+    }
+
+    return this.httpClient.delete({
+      url: nextURL,
+    });
+  }
 }

--- a/src/service/aightnowClient.ts
+++ b/src/service/aightnowClient.ts
@@ -8,6 +8,7 @@ export default class AightnowClient {
     this.generatePrompt = this.generatePrompt.bind(this);
     this.updateRecentSearch = this.updateRecentSearch.bind(this);
     this.deleteRecentSearch = this.deleteRecentSearch.bind(this);
+    this.getRecentSearch = this.getRecentSearch.bind(this);
   }
 
   async loginLLM({ isServer = false }: { isServer?: boolean } = {}) {
@@ -82,15 +83,22 @@ export default class AightnowClient {
     userId: UUID;
     stockId?: UUID | undefined;
   }) {
-    const nextURL = `/api/search/recent?type=${type}&userId=${userId}`;
-    const isAll = type === 'all';
-
-    if (!isAll) {
-      nextURL.concat('', `&stockId=${stockId}`);
-    }
+    const isSelected = type === 'select';
+    const selectedQ = isSelected ? `&stockId=${stockId}` : '';
+    const nextURL =
+      `/api/search/recent?type=${type}&userId=${userId}`.concat(
+        '',
+        selectedQ,
+      );
 
     return this.httpClient.delete({
       url: nextURL,
     });
+  }
+
+  async getRecentSearch({ userId }: { userId: UUID }) {
+    const nextURL = `/api/search/recent?userId=${userId}`;
+
+    return this.httpClient.get({ url: nextURL });
   }
 }

--- a/src/service/httpClient.ts
+++ b/src/service/httpClient.ts
@@ -98,7 +98,7 @@ export default class HttpClient {
     });
   }
 
-  async deleteRequest({
+  async delete({
     url,
     headers = {},
     isServer = false,

--- a/src/service/serviceType.d.ts
+++ b/src/service/serviceType.d.ts
@@ -1,3 +1,5 @@
+import { Locale } from '@/types/next-auth';
+
 interface HTTPParamType<BodyType = any> {
   url: string;
   method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
@@ -16,4 +18,22 @@ export interface GenerationRequest {
   userMessage: string;
   temperature: number;
   topP: number;
+}
+
+export interface UserData {
+  id: string;
+  userId: string;
+  email: string;
+  name: string;
+  role: string;
+  nickname: string;
+  profileImg: string;
+  profileImgName: string;
+  birth: string;
+  phoneNumber: string;
+  interestStock: string;
+  provider: string;
+  language: Locale;
+  accessToken: string;
+  refreshToken: string;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈> ex) #이슈번호, #이슈번호
#156 

## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
![recent-gif](https://github.com/user-attachments/assets/31a6fa44-0f7f-4651-a020-58f9ff0c4e31)
- AightnowClient Class를 활용해 최근 검색 종목 추가, 삭제 및 리스트 GET API 요청 로직 구현
- 헌상(@hunsang-you)님과 상의 후 관련 컴포넌트 기존 구조 및 로직 일부 변경

### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 구조 변경에 따른 QA 회의하며 진행하기로 결정
- 테스트 코드 도입 회의