### PR TITLE
[#241] 증권 거래소에 지정에 대한 네트워크 통신오류 해결

### DIFF
--- a/src/app/api/stock/naverpay/duration/route.ts
+++ b/src/app/api/stock/naverpay/duration/route.ts
@@ -7,7 +7,8 @@ export async function GET(req: NextRequest) {
   const amount = url.searchParams.get('amount');
   const range = amount ? `&range=${amount}` : '';
   const periodType = url.searchParams.get('unit');
-  const naverpayURL = `https://api.stock.naver.com/chart/foreign/item/${companies}?periodType=${periodType}${range}&stockExchangeType=NASDAQ`;
+  const stockExchangeType = url.searchParams.get('name');
+  const naverpayURL = `https://api.stock.naver.com/chart/foreign/item/${companies}?periodType=${periodType}${range}&stockExchangeType=${stockExchangeType}`;
   const payResponse = await fetch(naverpayURL);
   const payBody = await payResponse.json();
 

--- a/src/components/shared/chart/StockChartCard.tsx
+++ b/src/components/shared/chart/StockChartCard.tsx
@@ -9,9 +9,11 @@ import { useEffect, useState } from 'react';
 export default function StockChartCard({
   as,
   stockCode,
+  name,
 }: {
   as?: React.ElementType;
   stockCode: string;
+  name: string;
 }) {
   const [chartData, setChartData] = useState<AreaChartData>({
     amount: '',
@@ -24,14 +26,15 @@ export default function StockChartCard({
 
   useEffect(() => {
     handleRoute({ amount: 1, unit: 'day' });
-    if (stockCode) {
+    if (stockCode && name) {
       getPayDuration({
         amount: 1,
         unit: 'day',
         companies: stockCode,
+        name,
       }).then((res) => setChartData(res));
     }
-  }, [stockCode]);
+  }, [stockCode, name]);
 
   const handleDuration = (
     e:
@@ -58,9 +61,11 @@ export default function StockChartCard({
         unit,
       };
       handleRoute(duration);
-      getPayDuration({ ...duration, companies: stockCode }).then(
-        (res) => setChartData(res),
-      );
+      getPayDuration({
+        ...duration,
+        companies: stockCode,
+        name,
+      }).then((res) => setChartData(res));
     }
   };
 

--- a/src/components/stock/detail/ChartSection.tsx
+++ b/src/components/stock/detail/ChartSection.tsx
@@ -104,6 +104,9 @@ export default function ChartSection({ stockId }: { stockId: UUID }) {
       isInterest: isInterest,
     }));
   };
+  const stockExchangeName = (pay as StockResponse).datas?.[0]
+    ?.stockExchangeType?.name;
+
   return (
     <>
       <AddInterest
@@ -116,7 +119,11 @@ export default function ChartSection({ stockId }: { stockId: UUID }) {
           <StockDescription stock={stock} language={language} />
         </Wrapper>
         <Chart width="min-w-[692px]">
-          <Chart.StockChartCard as="h3" stockCode={stockCode} />
+          <Chart.StockChartCard
+            as="h3"
+            stockCode={stockCode}
+            name={stockExchangeName}
+          />
         </Chart>
       </div>
       <div className="flex justify-between box-border">

--- a/src/service/aightnowClient.ts
+++ b/src/service/aightnowClient.ts
@@ -299,12 +299,14 @@ export default class AightnowClient {
     companies,
     amount,
     unit,
+    name,
   }: {
     companies: string;
     amount: string | number;
     unit: string;
+    name: string;
   }) {
-    const nextURL = `/api/stock/naverpay/duration?companies=${companies}&amount=${amount}&unit=${unit}`;
+    const nextURL = `/api/stock/naverpay/duration?companies=${companies}&amount=${amount}&unit=${unit}&name=${name}`;
 
     return this.httpClient.get({ url: nextURL });
   }


### PR DESCRIPTION
## #️⃣연관된 이슈> ex) #이슈번호, #이슈번호
Close #235 

## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="1242" alt="스크린샷 2024-07-21 오후 8 51 34" src="https://github.com/user-attachments/assets/9ac5dd54-8ca7-4747-af7e-f56cb966f3c3">

- 증권 거래소에 대한 "name" 쿼리 스트링을 추가하여 API Route의 stockExchangeType 쿼리 스트링에서 활용


