### PR TITLE
[#253] Interest Layout에 Meta Title 적용

### DIFF
--- a/src/app/[locale]/(after)/stock/interest/layout.tsx
+++ b/src/app/[locale]/(after)/stock/interest/layout.tsx
@@ -1,4 +1,14 @@
 import IntlClientProvider from '@/components/shared/IntlClientProvider';
+import { getTranslations } from 'next-intl/server';
+
+export async function generateMetadata() {
+  const t = await getTranslations('Metadata');
+
+  return {
+    title: t('interest'),
+    description: 'Provide Interst Stocks.',
+  };
+}
 
 export default async function InterestLayout({
   children,

--- a/src/app/[locale]/(after)/stock/layout.tsx
+++ b/src/app/[locale]/(after)/stock/layout.tsx
@@ -9,7 +9,10 @@ export async function generateMetadata() {
   const t = await getTranslations('Metadata');
 
   return {
-    title: t('stock'),
+    title: {
+      template: `%s | ${t('app_name')}`,
+      default: t('stock'),
+    },
     description: 'Provide US stocks.',
   };
 }


### PR DESCRIPTION
## #️⃣연관된 이슈> ex) #이슈번호, #이슈번호
#249 

## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
<img width="545" alt="스크린샷 2024-07-23 오후 6 02 11" src="https://github.com/user-attachments/assets/b3714ca9-9354-428a-9c9b-90f2e7807afc">
- i18n을 통한 Meta Title 변경
- Stock Layout Meta Title이 template, default 속성을 사용하도록 변경
  - Interest Route가 Stock폴더 하위에 위치 

### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 현재 Interest는 Stock의 하위 경로에 포함돼있으나 하위 도메인 개념이 아니므로 폴더 구조 변경 필요