### PR TITLE
마이페이지 유저정보 수정/ 관심종목 기능 수정

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -271,6 +271,7 @@
     "birth": "Birth",
     "nickname": "Nickname",
     "duplicate": "Duplicate checking",
+    "duplicate_check": "Please check for duplicate IDs",
     "interest_stock": "Interest Stocks",
     "placeholder_nickname": "Please enter your nickname.",
     "placeholder_stock": "#Add a stock of interest.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -120,6 +120,7 @@
     "sign_up": "S'inscrire",
     "id": "Identifiant",
     "duplicate": "Vérification des doublons",
+    "duplicate_check": "Veuillez vérifier les identifiants en double",
     "pw": "Mot de passe",
     "confirm_pw": "Confirmer le mot de passe",
     "phone_number": "Numéro de téléphone",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -271,6 +271,7 @@
     "birth": "生年月日",
     "nickname": "ニックネーム",
     "duplicate": "重複チェック",
+    "duplicate_check": "IDの重複チェックを確認してください",
     "interest_stock": "関心銘柄",
     "placeholder_nickname": "ニックネームを入力してください。",
     "placeholder_stock": "#関心のある銘柄を追加してください。",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -271,6 +271,7 @@
     "birth": "생년월일",
     "nickname": "닉네임",
     "duplicate": "중복 확인",
+    "duplicate_check": "아이디 중복검사를 확인해주세요",
     "interest_stock": "관심 종목",
     "placeholder_nickname": "닉네임을 입력해주세요.",
     "placeholder_stock": "#관심종목을 추가해주세요.",

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -272,6 +272,7 @@
     "birth": "出生日期",
     "nickname": "昵称",
     "duplicate": "重复检查",
+    "duplicate_check": "请检查重复的ID",
     "interest_stock": "关注股票",
     "placeholder_nickname": "请输入您的昵称。",
     "placeholder_stock": "#添加关注的股票。",

--- a/src/app/api/mypage/profile/route.ts
+++ b/src/app/api/mypage/profile/route.ts
@@ -2,9 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import supabase from '@/lib/supabaseClient'; // Supabase 클라이언트 가져오기
 import {
   deleteProfileImage,
+  updateInterestStocks,
   uploadProfileImage,
 } from '@/utils/supabase/supabaseHelper';
 import generateFileName from '@/utils/generateFileName';
+import { UUID } from 'crypto';
 
 type UpdateData = {
   data: {
@@ -18,6 +20,7 @@ type UpdateData = {
 export async function POST(request: NextRequest) {
   try {
     const formData = await request.formData();
+    const id = formData.get('id') as UUID;
     const profileImg = formData.get('profileImg') as File;
     const nickname = formData.get('nickname') as string;
     const interestStock = formData.get('interestStock') as string;
@@ -50,7 +53,6 @@ export async function POST(request: NextRequest) {
     const updateData: UpdateData = {
       data: {
         nickname,
-        interestStock,
       },
     };
 
@@ -71,11 +73,14 @@ export async function POST(request: NextRequest) {
       updateData.data.profileImgName = fileName;
     }
 
+    // 관심 종목 업데이트
+    await updateInterestStocks(id, interestStock);
+
     // 유저 정보 업데이트
     const { data, error: authError } = await supabase.auth.updateUser(
       updateData,
     );
-    // console.log('---------수정 업데이트---------', data);
+
     if (authError) {
       throw authError;
     }

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -84,8 +84,8 @@ export async function POST(request: NextRequest) {
     }
 
     // 프로필 이미지 supabase 스토리지에 저장
-    let profileFileImageUrl: any = null; //이미지 파일 url
-    let profilFileImageName: any = null; //이미지 이름
+    let profileFileImageUrl: string | null = null; //이미지 파일 url
+    let profilFileImageName: string | null = null; //이미지 이름
     if (profileImg && profileImg.name) {
       profilFileImageName = generateFileName(profileImg?.name);
 
@@ -109,13 +109,14 @@ export async function POST(request: NextRequest) {
           profileImg: profileFileImageUrl,
           profileImgName: profilFileImageName,
           nickname,
-          interestStock,
           provider_account_id: providerAccountId,
+          interestStock,
+          // 관심종목 supabae 함수,트리거를 사용해 회원가입시
+          // stock 테이블과 비교하여 interest_stock에 삽입
           // language: 'kr', //언어 설정 값 기본 'kr'
         },
       },
     });
-
     if (error) {
       throw error;
     }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -67,7 +67,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           profileImgName: loginData.user.user_metadata.profileImgName,
           birth: loginData.user.user_metadata.birth,
           phoneNumber: loginData.user.user_metadata.phoneNumber,
-          interestStock: loginData.user.user_metadata.interestStock,
           provider: loginData.user.user_metadata.provider_account_id,
           userId: loginData.user.user_metadata.userId,
           language: loginData.user.user_metadata.language,
@@ -184,8 +183,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           user.birth = socialLogin.user.user_metadata.birth;
           user.phoneNumber =
             socialLogin.user.user_metadata.phoneNumber;
-          user.interestStock =
-            socialLogin.user.user_metadata.interestStock;
           user.provider =
             socialLogin.user.user_metadata.provider_account_id;
           user.language = socialLogin.user.user_metadata.language;
@@ -210,7 +207,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         token.profileImgName = user.profileImgName;
         token.birth = user.birth;
         token.phoneNumber = user.phoneNumber;
-        token.interestStock = user.interestStock;
         token.provider = user.provider;
         token.language = user.language;
         token.accessToken = user.accessToken;
@@ -231,7 +227,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           nickname,
           profileImg,
           profileImgName,
-          interestStock,
+          // interestStock,
           language,
         } = session;
 
@@ -242,7 +238,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         token.nickname = nickname;
         token.profileImg = profileImg;
         token.profileImgName = profileImgName;
-        token.interestStock = interestStock;
+        // token.interestStock = interestStock;
         token.language = language;
       }
       return token;
@@ -261,7 +257,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         session.user.profileImgName = token.profileImgName;
         session.user.birth = token.birth;
         session.user.phoneNumber = token.phoneNumber;
-        session.user.interestStock = token.interestStock;
         session.user.provider = token.provider;
         session.user.language = token.language;
         session.user.accessToken = token.accessToken;

--- a/src/components/shared/ProfileDetails.tsx
+++ b/src/components/shared/ProfileDetails.tsx
@@ -1,4 +1,4 @@
-import React, { KeyboardEvent } from 'react';
+import React, { KeyboardEvent, useEffect, useState } from 'react';
 import InputSet from '@/components/shared/input/index';
 import CompositeInput from '@/components/shared/input/CompositeInput/index';
 import TextButton from '@/components/shared/buttons/TextButton';
@@ -7,8 +7,10 @@ import CompositeDropdown from './dropdown/compositeDropdown';
 import { SelectedOption } from './dropdown/types';
 import { renderDropdownOptions } from './dropdown/renderDropdownDoptions';
 import { useTranslations } from 'next-intl';
+import SkeletonProfileUpdated from '../skeleton/mypage/SkeletonProfileUpdated';
 
 type ProfileDetails = {
+  isLoading?: boolean;
   profileImage: string;
   handleImageUpload: (e: React.ChangeEvent<HTMLInputElement>) => void;
   nickname: string;
@@ -29,6 +31,7 @@ type ProfileDetails = {
 };
 
 export default function ProfileDetails({
+  isLoading = false,
   profileImage,
   handleImageUpload,
   nickname,
@@ -45,59 +48,77 @@ export default function ProfileDetails({
   handleOptionsKey,
 }: ProfileDetails) {
   const t = useTranslations('MyPage');
+  const [isInputChanged, setIsInputChanged] = useState(false);
+
+  const handleStockChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setStock(e.target.value);
+    if (!isInputChanged) {
+      setIsInputChanged(true);
+    }
+  };
 
   return (
-    <form
-      onSubmit={onHandleSubmit}
-      className="flex flex-col justify-center items-center w-full pr-4"
-    >
-      <ProfileImageEditor
-        profileImage={profileImage}
-        handleImageUpload={handleImageUpload}
-      />
-      <InputSet className="flex flex-col gap-4 w-[386px]">
-        <InputSet.Validated
-          onChange={onChangeNickname}
-          value={nickname}
-          type="text"
-          concept="nickname"
-          isSubmit={isSubmit}
-        />
-        <CompositeInput className="flex flex-col justify-between items-left max-w-[386px] gap-1">
-          <CompositeInput.Label
-            htmlFor="stock"
-            className="b4 font-medium"
-          >
-            {t('interest_stock')}
-          </CompositeInput.Label>
-          <CompositeInput.Input
-            id="stock"
-            type="text"
-            value={stock}
-            onChange={(e) => setStock(e.target.value)}
-            className="border border-grayscale-400 b4 font-normal placeholder-grayscale-400 p-4 rounded-lg"
-            placeholder={t('placeholder_stock')}
+    <>
+      {isLoading ? (
+        <SkeletonProfileUpdated />
+      ) : (
+        <form
+          onSubmit={onHandleSubmit}
+          className="flex flex-col justify-center items-center w-full pr-4"
+        >
+          <ProfileImageEditor
+            profileImage={profileImage}
+            handleImageUpload={handleImageUpload}
           />
-          {options?.length > 0 && stock.length > 0 && (
-            <CompositeDropdown.Panel
-              onClick={handleSelected}
-              handleOptionsKey={handleOptionsKey}
-              className="border border-grayscale-400 rounded-lg h-52 overflow-y-auto no-scrollbar"
-            >
-              {() =>
-                renderDropdownOptions(
-                  options,
-                  selectedDataset,
-                  focusedIndex,
-                )
-              }
-            </CompositeDropdown.Panel>
-          )}
-          <TextButton type="submit" className="w-full mt-8">
-            {buttonText}
-          </TextButton>
-        </CompositeInput>
-      </InputSet>
-    </form>
+          <InputSet className="flex flex-col gap-4 w-[386px]">
+            <InputSet.Validated
+              onChange={onChangeNickname}
+              value={nickname}
+              type="text"
+              concept="nickname"
+              isSubmit={isSubmit}
+            />
+            <CompositeInput className="flex flex-col justify-between items-left max-w-[386px] gap-1">
+              <CompositeInput.Label
+                htmlFor="stock"
+                className="b4 font-medium"
+              >
+                {t('interest_stock')}
+              </CompositeInput.Label>
+              <CompositeInput.Input
+                id="stock"
+                type="text"
+                value={stock}
+                onChange={handleStockChange}
+                className="border border-grayscale-400 b4 font-normal placeholder-grayscale-400 p-4 rounded-lg"
+                placeholder={t('placeholder_stock')}
+              />
+              {options?.length > 0 &&
+                stock.length > 0 &&
+                isInputChanged && (
+                  <CompositeDropdown.Panel
+                    onClick={handleSelected}
+                    handleOptionsKey={handleOptionsKey}
+                    className="border border-grayscale-400 rounded-lg h-52 overflow-y-auto no-scrollbar"
+                  >
+                    {() =>
+                      renderDropdownOptions(
+                        options,
+                        selectedDataset,
+                        focusedIndex,
+                      )
+                    }
+                  </CompositeDropdown.Panel>
+                )}
+              <TextButton type="submit" className="w-full mt-8">
+                {buttonText}
+              </TextButton>
+            </CompositeInput>
+          </InputSet>
+        </form>
+      )}
+    </>
   );
 }

--- a/src/components/signup/ProfileSetup.tsx
+++ b/src/components/signup/ProfileSetup.tsx
@@ -10,7 +10,6 @@ import LoadingSpinnerWrapper from '../shared/LoadingSpinnerWrapper';
 import usePopupStore from '@/store/userPopup';
 import { useImageUpload } from '@/hooks/user/useImageUpload';
 import { useStockSelection } from '@/hooks/user/useStockSelection';
-import { stockList } from '@/constants';
 import { useTranslations } from 'next-intl';
 
 // 마이페이지 설정에서 모달 과 회원가입 페이지에서 사용
@@ -31,26 +30,16 @@ export default function ProfileSetup() {
     usePopupStore();
 
   const {
-    stock,
-    setStock,
+    searchText,
+    setSearchText,
     options,
     selectedDataset,
     focusedIndex,
     handleSelected,
     handleOptionsKey,
-  } = useStockSelection(''); // 관심종목 설정 훅
+    validateAndUpdateStock,
+  } = useStockSelection(); // 관심종목 설정 훅
 
-  // 유효하지 않은 주식 값 제거
-  const validateAndUpdateStock = () => {
-    const validStocks = stock
-      .split(' ')
-      .filter(
-        (part) => part.startsWith('#') && stockList.includes(part),
-      ) // #으로 시작하고 유효한 주식인지 검사
-      .join(' ');
-
-    return validStocks;
-  };
   const validateForm = useCallback(() => {
     const isNicknameValid = conceptMap.nickname.doValidation(
       value.nickname,
@@ -68,9 +57,9 @@ export default function ProfileSetup() {
     if (!isFormValid) return;
     setIsFormValid(false);
     setIsLoading(true);
-
-    const validStock = validateAndUpdateStock(); // 유효하지 않은 입력, 주식 값 제거
-
+    // 관심종목 id값 text로 변환
+    const validStock = validateAndUpdateStock(searchText); // 유효하지 않은 입력, 주식 값 제거
+    setIsFormValid(false);
     const formData = new FormData();
     formData.append('nickname', value.nickname.trim());
     formData.append('interestStock', validStock);
@@ -124,8 +113,8 @@ export default function ProfileSetup() {
               isSubmit={isSubmit}
               options={options}
               focusedIndex={focusedIndex}
-              stock={stock}
-              setStock={setStock}
+              stock={searchText}
+              setStock={setSearchText}
               selectedDataset={selectedDataset}
               handleSelected={handleSelected}
               handleOptionsKey={handleOptionsKey}

--- a/src/components/skeleton/mypage/SkeletonProfileUpdated.tsx
+++ b/src/components/skeleton/mypage/SkeletonProfileUpdated.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import SkeletonText from '../shared/SkeletonText';
+
+export default function SkeletonProfileUpdated() {
+  return (
+    <div className="flex flex-col justify-center items-center w-full pr-6">
+      <div className="flex flex-col items-center mb-10">
+        <SkeletonText type="h3" className="w-32 h-32" />
+      </div>
+      <div className="flex flex-col gap-6 w-[386px]">
+        <div className="flex flex-col gap-1">
+          <SkeletonText type="b2" className="w-20" />
+          <SkeletonText type="h3" className="w-full" />
+        </div>
+        <div className="flex flex-col gap-1">
+          <SkeletonText type="b2" className="w-20" />
+          <SkeletonText type="h3" className="w-full" />
+        </div>
+      </div>
+      <SkeletonText type="h2" className="w-96 h-14 mt-8" />
+    </div>
+  );
+}

--- a/src/components/user/UserAccountEdit.tsx
+++ b/src/components/user/UserAccountEdit.tsx
@@ -28,7 +28,7 @@ export default function UserAccountEdit({
   user,
   isSocial,
 }: UserAccountEdit) {
-  const t = useTranslations();
+  const t = useTranslations('MyPage');
   const { openModal, closeModal, closeAllModals, isUserAccountdit } =
     myPageStore();
 
@@ -36,13 +36,18 @@ export default function UserAccountEdit({
   const [isSubmit, setIsSubmit] = useState(false); // 폼 submit
   const [isFormValid, setIsFormValid] = useState(false); //폼 유효성 체크
   const { isLoading, duplicatedCheck, handleDuplicate } =
-    useDuplicateCheck(value.signupId); //Id 중복검사
+    useDuplicateCheck(value.signupId, user?.userId); //Id 중복검사
 
   const { isLoading: updateLoading, handleAccountUpdate } =
     useAccountUpdated(); //개인정보 수정 api
 
-  const { isShowPopup, popupMsg, hidePopup, isConfirmPopup } =
-    usePopupStore();
+  const {
+    isShowPopup,
+    popupMsg,
+    hidePopup,
+    isConfirmPopup,
+    showPopup,
+  } = usePopupStore();
 
   const {
     isUpdatePwLoading,
@@ -80,7 +85,7 @@ export default function UserAccountEdit({
     e.preventDefault();
     setIsSubmit(true);
     if (!duplicatedCheck && !isSocial)
-      window.alert('아이디 중복검사를 확인해주세요');
+      showPopup(t('profileUpdate.error_title'), t('duplicate_check'));
     if (!isFormValid) return;
     const formData = new FormData();
     formData.append('userId', value.signupId.trim());
@@ -149,7 +154,7 @@ export default function UserAccountEdit({
         <ModalLayout
           isOpen={isUserAccountdit}
           handleIsOpen={handleCloseAccountModal}
-          title={t('MyPage.edit_account')}
+          title={t('edit_account')}
           width="w-[590px]"
         >
           <LoadingSpinnerWrapper

--- a/src/hooks/user/useAccountUpdated.ts
+++ b/src/hooks/user/useAccountUpdated.ts
@@ -4,6 +4,7 @@ import { updateUserData } from '@/utils/user/updateUserData';
 import usePopupStore from '@/store/userPopup';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
+import myPageStore from '@/store/myPageStore';
 
 // 계정 수정 커스텀 훅
 export function useAccountUpdated() {
@@ -12,6 +13,7 @@ export function useAccountUpdated() {
   const [isLoading, setIsLoading] = useState(false);
   const t = useTranslations();
   const { showPopup } = usePopupStore();
+  const { closeAllModals } = myPageStore();
 
   const handleAccountUpdate = async (formData: FormData) => {
     setIsLoading(true);
@@ -20,6 +22,7 @@ export function useAccountUpdated() {
       formData,
       update,
       showPopup,
+      closeAllModals,
       {
         successTitle: t('MyPage.profileUpdate.success_title'),
         successMessage: t('MyPage.profileUpdate.success_message'),

--- a/src/hooks/user/useDuplicateCheck.ts
+++ b/src/hooks/user/useDuplicateCheck.ts
@@ -1,11 +1,23 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 // id 중복 검사 커스텀 훅
 // api 로딩, handleDuplicate 함수 관리
 // 인자로 id를 받아야함
-const useDuplicateCheck = (id : string) => {
+// previousValue 값으로 중복검사 이후에 id변경시 재중복검사 요청
+const useDuplicateCheck = (id: string, initialId?: string) => {
   const [isLoading, setIsLoading] = useState(false);
   const [duplicatedCheck, setDuplicatedCheck] = useState(false);
+  const [previousValue, setPreviousValue] = useState('');
+
+  // 수정시 initalId 값과 id 값이같다면 중복검사 건너뛰기
+  useEffect(() => {
+    if (initialId && id === initialId) {
+      setDuplicatedCheck(true);
+    } else if (id !== previousValue) {
+      // 중복검사 이후 id값 변경 시 다시 중복검사 유도
+      setDuplicatedCheck(false);
+    }
+  }, [id, initialId, previousValue]);
 
   const handleDuplicate = async () => {
     setIsLoading(true);
@@ -17,6 +29,7 @@ const useDuplicateCheck = (id : string) => {
       return 'duplicate';
     } else {
       setIsLoading(false);
+      setPreviousValue(id);
       setDuplicatedCheck(true);
       return 'possible';
     }

--- a/src/hooks/user/useProfileUpdated.ts
+++ b/src/hooks/user/useProfileUpdated.ts
@@ -5,6 +5,7 @@ import usePopupStore from '@/store/userPopup';
 import { useTranslations } from 'next-intl';
 import { useRouter } from 'next/navigation';
 import { UpdateResponse } from '@/types/mypage';
+import myPageStore from '@/store/myPageStore';
 
 // 프로필 수정 커스텀 훅
 // api 수정 로딩 값, 팝업 메세지, 세션 업데이트 관리
@@ -13,6 +14,7 @@ export function useProfileUpdate() {
   const { update } = useSession();
   const [isLoading, setIsLoading] = useState(false);
   const { showPopup } = usePopupStore();
+  const { closeAllModals } = myPageStore();
   const t = useTranslations();
 
   const handleProfileUpdate = async (formData: FormData) => {
@@ -22,6 +24,7 @@ export function useProfileUpdate() {
       formData,
       update,
       showPopup,
+      closeAllModals,
       {
         successTitle: t('MyPage.profileUpdate.success_title'),
         successMessage: t('MyPage.profileUpdate.success_message'),

--- a/src/hooks/user/useStockSelection.ts
+++ b/src/hooks/user/useStockSelection.ts
@@ -1,46 +1,89 @@
 import { useEffect, useState } from 'react';
 import { SelectedOption } from '@/components/shared/dropdown/types';
-type Stock = {
-  compare_to_previous_close_price: number;
-  description_en: string;
-  description_fr: string;
-  description_ja: string;
-  description_ko: string;
-  description_zh: string;
-  fluctuations_ratio: number;
-  logo_path: string;
-  price: number;
-  stock_code: string;
-  stock_id: string;
-  stock_name: string;
-  view: number;
+import { businessAPI } from '@/service/apiInstance';
+import { Stock } from '@/types/stock';
+import { UUID } from 'crypto';
+import { stockList } from '@/constants';
+
+type SelectStock = {
+  text: string;
+  value: string;
 };
 
-export const useStockSelection = (initialStock = '') => {
-  const [stock, setStock] = useState(initialStock);
+export const useStockSelection = (userId?: UUID) => {
+  const [stock, setStock] = useState<SelectStock[]>([]);
+  const [searchText, setSearchText] = useState('');
   const [selectedDataset, setSelectedDataset] = useState('');
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [options, setOptions] = useState<SelectedOption[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
 
-//#으로 시작하는 문자열 제외 함수
-const extractSearchText = (stock: string): string => {
-  return stock
-    .split(' ')
-    .filter((part) => !part.startsWith('#'))
-    .join(' ');
-};
+  const { getInterestStock } = businessAPI;
+
+  // 유저 기존 관심 종목 가져오기
+  const getInterest = () => {
+    if (!isLoading && userId) {
+      setIsLoading(true);
+      getInterestStock({ userId, page: 1, size: 17 })
+        .then((stocksRes) => {
+          if (stocksRes.length !== 0) {
+            const stockArray: SelectStock[] = stocksRes.map(
+              ({ stock }: { stock: Stock }) => ({
+                text: `#${stock.stock_name}`,
+                value: stock.stock_id,
+              }),
+            );
+            setStock(stockArray);
+
+            const userStock = stocksRes
+              .map(
+                ({ stock }: { stock: Stock }) =>
+                  `#${stock.stock_name}`,
+              )
+              .join(' ');
+            setSearchText(userStock);
+          }
+          setIsLoading(false);
+        })
+        .catch((e) => {
+          setIsLoading(false);
+        });
+    }
+  };
+
+  useEffect(() => {
+    if (userId) {
+      getInterest();
+    }
+  }, [userId]);
+
+  // stock 상태가 변경될 때마다 searchText를 업데이트
+  useEffect(() => {
+    const updatedSearchText = stock
+      .map((stock) => stock.text)
+      .join(' ');
+    setSearchText(updatedSearchText);
+  }, [stock]);
+
+  //#으로 시작하는 문자열 제외 함수
+  const extractSearchText = (stock: string): string => {
+    return stock
+      .split(' ')
+      .filter((part) => !part.startsWith('#'))
+      .join(' ');
+  };
 
   useEffect(() => {
     const fetchStocks = async () => {
-      const searchText = extractSearchText(stock);
+      const text = extractSearchText(searchText);
       const response = await fetch(
-        `/api/search/stock?searchText=${searchText}`,
+        `/api/search/stock?searchText=${text}`,
       );
 
       if (response.ok) {
         const data = await response.json();
         const newStockOptions = data?.map((stock: Stock) => ({
-          value: stock.stock_code,
+          value: stock.stock_id,
           text: stock.stock_name,
         }));
 
@@ -52,30 +95,54 @@ const extractSearchText = (stock: string): string => {
     }, 500);
 
     return () => clearTimeout(debounceTimeout);
-  }, [stock]);
+  }, [searchText]);
 
   const handleSelected = (value: string) => {
     const selectedOption = options.find(
       (item) => item.value === value,
     );
-    // 기존의 #으로 시작하지 않는 값들을 제거
-    const cleanedStock = stock
-      .split(' ')
-      .filter((part) => part.startsWith('#'))
-      .join(' ');
 
     if (selectedOption) {
-      const newStock = `#${selectedOption.text}`;
-      if (cleanedStock.includes(newStock)) {
-        setStock((prev) => prev.replace(newStock, '').trim());
-        setSelectedDataset('');
-      } else {
-        setStock((prev) =>
-          cleanedStock ? `${cleanedStock} ${newStock}` : newStock,
+      const newStock = {
+        text: `#${selectedOption.text}`,
+        value: selectedOption.value,
+      };
+      console.log('value', value);
+      setStock((prevStock) => {
+        // 현재 searchText와 일치하지 않는 prevStock 항목을 필터링하여 제거
+        const filteredPrevStock = prevStock.filter((stockItem) =>
+          searchText.includes(stockItem.text),
         );
-        setSelectedDataset(value);
-      }
+        if (filteredPrevStock.length < 1) {
+          return [newStock];
+        }
+        const exists = filteredPrevStock?.find(
+          (stockItem) => stockItem.value === value,
+        );
+        let updatedStock;
+        if (exists) {
+          updatedStock = filteredPrevStock.filter(
+            (stockItem) => stockItem.value !== value,
+          );
+        } else {
+          updatedStock = [...filteredPrevStock, newStock];
+        }
+        return updatedStock;
+      });
+      setSelectedDataset(value);
     }
+  };
+
+  // 유효하지 않은 주식 값 제거
+  const validateAndUpdateStock = (searchText: string) => {
+    const validStocks = searchText
+      .split(' ')
+      .filter(
+        (part) => part.startsWith('#') && stockList.includes(part),
+      ) // #으로 시작하고 유효한 주식인지 검사
+      .join(' ');
+
+    return validStocks;
   };
 
   function handleOptionsKey(
@@ -107,15 +174,17 @@ const extractSearchText = (stock: string): string => {
         break;
     }
   }
-  
+
   return {
-    stock,
-    setStock,
+    searchText,
+    isLoading,
+    setSearchText,
     options,
     selectedDataset,
     focusedIndex,
     setFocusedIndex,
     handleSelected,
     handleOptionsKey,
+    validateAndUpdateStock,
   };
 };

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -14,7 +14,6 @@ declare module 'next-auth' {
       profileImgName: string;
       birth: string;
       phoneNumber: string;
-      interestStock: string;
       provider: string;
       language: Locale;
       accessToken: string;
@@ -33,7 +32,6 @@ declare module 'next-auth' {
     profileImgName: string;
     birth: string;
     phoneNumber: string;
-    interestStock: string;
     provider: string;
     language: Locale;
     accessToken: string;

--- a/src/utils/user/updateUserData.ts
+++ b/src/utils/user/updateUserData.ts
@@ -6,6 +6,7 @@ export async function updateUserData(
   formData: FormData,
   update: UpdateSession,
   showPopup: (title: string, msg: string) => void,
+  closeAllModals: () => void,
   translations: {
     successTitle: string;
     successMessage: string;
@@ -26,6 +27,7 @@ export async function updateUserData(
         translations.successTitle,
         translations.successMessage,
       );
+      closeAllModals();
     } else {
       const data: UpdateResponse = await response.json();
       if (data.error === 'SessionExpired') {


### PR DESCRIPTION
## #️⃣연관된 이슈> ex) #이슈번호, #이슈번호
#264 
## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
-  next-auth 유저session  interestStock제거
- 마이페이지 유정 정보 수정 성공 시 모달 창 닫기
- 회원가입시 supabase 함수,트리거를 사용해 interestStock 메타데이터 값 stock 테이블과 비교하여 interest_stock 테이블에 추가
- 프로필 관심종목 수정 시 석호님이 작성하신 getInterestStock활용 및 유저 관심종목 세팅
- 관심종목 text입력전까지 렌더링 발생 방지
- useStockSelection 훅 수정, searchText, stock  2개의 상태값으로 유저 관심종목 검색 input 관리
- 프로필 수정  로딩 스켈레톤 ui 작성
- useDuplicateCheck 훅 수정, 중복 검사 이후 유저가 id값 수정시 팝업 발생
### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
