### PR TITLE
release #269 : 급상승, 급하락 종목 로직 수정

### DIFF
--- a/src/app/api/stock/decrease/route.ts
+++ b/src/app/api/stock/decrease/route.ts
@@ -7,6 +7,7 @@ export async function GET() {
     .from('stock')
     .select()
     .order('fluctuations_ratio', { ascending: true })
+    .lt('fluctuations_ratio', 0)
     .limit(4);
   // console.log(stockList);
   return Response.json({ stockList });

--- a/src/app/api/stock/increase/route.ts
+++ b/src/app/api/stock/increase/route.ts
@@ -7,6 +7,7 @@ export async function GET() {
     .from('stock')
     .select()
     .order('fluctuations_ratio', { ascending: false })
+    .gt('fluctuations_ratio', 0)
     .limit(4);
   // console.log(stockList);
   return Response.json({ stockList });

--- a/src/components/shared/StockListItem.tsx
+++ b/src/components/shared/StockListItem.tsx
@@ -33,7 +33,7 @@ function getKoreanName(stockName: StockNames): string {
   return nameToKO[stockName];
 }
 
-export default function StockListItem({
+function StockListItem({
   stock,
   type = 'default',
 }: StockListItemProps) {
@@ -240,3 +240,5 @@ export default function StockListItem({
     </>
   );
 }
+
+export default React.memo(StockListItem);

--- a/src/components/stock/LimitStocks.tsx
+++ b/src/components/stock/LimitStocks.tsx
@@ -15,7 +15,7 @@ export default async function LimitStocks({
   ).json();
   // console.log(stockList);
   return (
-    <div className="flex flex-col  bg-[#FFFFFF] rounded-2xl mt-6 px-8 py-6">
+    <div className="flex flex-col  bg-[#FFFFFF] rounded-2xl mt-6 px-8 py-6 min-h-[368px]">
       {stockList.map((stock) => (
         <div
           key={stock.stock_id}


### PR DESCRIPTION
## #️⃣연관된 이슈> #269

## 📝작업 내용> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 양수일 떄만 급상승 종목에 포함
- 음수일 떄만 급하락 종목에 포함
### 스크린샷 (선택)## 💬리뷰 요구사항(선택)> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
